### PR TITLE
Don't fork when run as a systemd service

### DIFF
--- a/init/couchpotato.service
+++ b/init/couchpotato.service
@@ -3,9 +3,8 @@ Description=CouchPotato application instance
 After=network.target
 
 [Service]
-ExecStart=/var/lib/CouchPotatoServer/CouchPotato.py --daemon 
-GuessMainPID=no
-Type=forking
+ExecStart=/var/lib/CouchPotatoServer/CouchPotato.py
+Type=simple
 User=couchpotato
 Group=couchpotato
 


### PR DESCRIPTION
systemd is able to track services much better when it is the direct parent of a service process. Forking (via daemonize) hinders this ability.