### PR TITLE
fix xbmc mpaa rating metadata

### DIFF
--- a/couchpotato/core/media/movie/providers/metadata/xbmc.py
+++ b/couchpotato/core/media/movie/providers/metadata/xbmc.py
@@ -84,8 +84,15 @@ class XBMC(MovieMetaData):
         except:
             pass
 
+        # mpaa
+        try:
+            mpaa = SubElement(nfoxml, 'mpaa')
+            mpaa.text = toUnicode('Rated %s' % movie_info.get('mpaa'))
+        except:
+            pass
+
         # Other values
-        types = ['year', 'mpaa', 'originaltitle:original_title', 'outline', 'plot', 'tagline', 'premiered:released']
+        types = ['year', 'originaltitle:original_title', 'outline', 'plot', 'tagline', 'premiered:released']
         for type in types:
 
             if ':' in type:


### PR DESCRIPTION
xbmc is unable to parse mpaa rating metadata unless it says "Rated"