### PR TITLE
Synology downloader error handling

### DIFF
--- a/couchpotato/core/downloaders/synology.py
+++ b/couchpotato/core/downloaders/synology.py
@@ -38,7 +38,7 @@ class Synology(DownloaderBase):
         if not data: data = {}
 
         response = False
-        log.error('Sending "%s" (%s) to Synology.', (data['name'], data['protocol']))
+        log.info('Sending "%s" (%s) to Synology.', (data['name'], data['protocol']))
 
         # Load host from config and split out port.
         host = cleanHost(self.conf('host'), protocol = False).split(':')

--- a/couchpotato/core/downloaders/synology.py
+++ b/couchpotato/core/downloaders/synology.py
@@ -173,7 +173,22 @@ class SynologyRPC(object):
                 log.info('Login success, adding torrent URI')
                 args['uri'] = url
                 response = self._req(self.download_url, args = args)
-                log.info('Response: %s', response)
+                if response['success']:
+                    log.info('Response: %s', response)
+                else:
+                    log.error('Response: %s', response)
+                    synoerrortype = {
+                        400 : 'File upload failed',
+                        401 : 'Max number of tasks reached',
+                        402 : 'Destination denied',
+                        403 : 'Destination does not exist',
+                        404 : 'Invalid task id',
+                        405 : 'Invalid task action',
+                        406 : 'No default destination',
+                        407 : 'Set destination failed',
+                        408 : 'File does not exist'
+                    }
+                    log.error('DownloadStation returned the following error : %s', synoerrortype[response['error']['code']])
                 result = response['success']
             elif filename and filedata:
                 log.info('Login success, adding torrent')

--- a/couchpotato/core/downloaders/synology.py
+++ b/couchpotato/core/downloaders/synology.py
@@ -28,10 +28,10 @@ class Synology(DownloaderBase):
             Used for creating the filename when possible
         :param filedata: downloaded torrent/nzb filedata
             The file gets downloaded in the searcher and send to this function
-            This is done to have failed checking before using the downloader, so the downloader
+            This is done to have fail checking before using the downloader, so the downloader
             doesn't need to worry about that
         :return: boolean
-            One faile returns false, but the downloaded should log his own errors
+            One fail returns false, but the downloader should log his own errors
         """
 
         if not media: media = {}
@@ -124,7 +124,7 @@ class SynologyRPC(object):
                 self.sid = response['data']['sid']
                 log.debug('sid=%s', self.sid)
             else:
-                log.error('Couldn\'t login to Synology, %s', response)
+                log.error('Couldn\'t log into Synology, %s', response)
             return response['success']
         else:
             log.error('User or password missing, not using authentication.')


### PR DESCRIPTION


Improved the log details when using Synology DownloadStation as a downloader. I added messages for the API error codes when creating a task and changed some log levels to be in line with the type of message.

I'm not sure my platform is perfect for the full range of testing so maybe this needs a quick check, but the changes are supposed to be pretty basic, no structure, just printing.
