### PR TITLE
Ability to hide "Update" link from UI (tab "About")

### DIFF
--- a/couchpotato/static/scripts/combined.base.min.js
+++ b/couchpotato/static/scripts/combined.base.min.js
@@ -2027,7 +2027,8 @@ var AboutSettingTab = new Class({
             self.createAbout();
         });
         self.settings.default_action = "about";
-        self.hide_dirs = !!App.options && App.options.webui_feature && App.options.webui_feature.hide_about_dirs;
+        self.hide_about_dirs = !!App.options && App.options.webui_feature && App.options.webui_feature.hide_about_dirs;
+        self.hide_about_update = !!App.options && App.options.webui_feature && App.options.webui_feature.hide_about_update;
     },
     createAbout: function() {
         var self = this;
@@ -2037,8 +2038,12 @@ var AboutSettingTab = new Class({
             label: "About This CouchPotato",
             name: "variables"
         }).inject(self.content).adopt((about_block = new Element("dl.info")).adopt(new Element("dt[text=Version]"), self.version_text = new Element("dd.version", {
-            text: "Getting version...",
-            events: {
+            text: "Getting version..."
+        }), new Element("dt[text=Updater]"), self.updater_type = new Element("dd.updater"), new Element("dt[text=ID]"), new Element("dd", {
+            text: App.getOption("pid")
+        })));
+        if (!self.hide_about_update) {
+            self.version_text.addEvents({
                 click: App.checkForUpdate.bind(App, function(json) {
                     self.fillVersion(json.info);
                 }),
@@ -2048,11 +2053,11 @@ var AboutSettingTab = new Class({
                 mouseleave: function() {
                     self.fillVersion(Updater.getInfo());
                 }
-            }
-        }), new Element("dt[text=Updater]"), self.updater_type = new Element("dd.updater"), new Element("dt[text=ID]"), new Element("dd", {
-            text: App.getOption("pid")
-        })));
-        if (!self.hide_dirs) {
+            });
+        } else {
+            self.version_text.setProperty("style", "cursor: auto");
+        }
+        if (!self.hide_about_dirs) {
             about_block.adopt(new Element("dt[text=Directories]"), new Element("dd", {
                 text: App.getOption("app_dir")
             }), new Element("dd", {

--- a/couchpotato/static/scripts/page/about.js
+++ b/couchpotato/static/scripts/page/about.js
@@ -29,7 +29,8 @@ var AboutSettingTab = new Class({
 
 		self.settings.default_action = 'about';
 		// WebUI Feature:
-		self.hide_dirs = !! App.options && App.options.webui_feature && App.options.webui_feature.hide_about_dirs;
+		self.hide_about_dirs = !! App.options && App.options.webui_feature && App.options.webui_feature.hide_about_dirs;
+		self.hide_about_update = !! App.options && App.options.webui_feature && App.options.webui_feature.hide_about_update;
 	},
 
 	createAbout: function(){
@@ -48,29 +49,34 @@ var AboutSettingTab = new Class({
 			(about_block = new Element('dl.info')).adopt(
 				new Element('dt[text=Version]'),
 				self.version_text = new Element('dd.version', {
-					'text': 'Getting version...',
-					'events': {
-						'click': App.checkForUpdate.bind(App, function(json){
-							self.fillVersion(json.info);
-						}),
-						'mouseenter': function(){
-							this.set('text', 'Check for updates');
-						},
-						'mouseleave': function(){
-							self.fillVersion(Updater.getInfo());
-						}
-					}
+					'text': 'Getting version...'
 				}),
 
 				new Element('dt[text=Updater]'),
 				self.updater_type = new Element('dd.updater'),
 				new Element('dt[text=ID]'),
 				new Element('dd', {'text': App.getOption('pid')})
-
 			)
 		);
 
-		if (!self.hide_dirs){
+		if (!self.hide_about_update){
+			self.version_text.addEvents({		
+				'click': App.checkForUpdate.bind(App, function(json){
+					self.fillVersion(json.info);
+				}),			
+				'mouseenter': function(){
+					this.set('text', 'Check for updates');
+				},
+				'mouseleave': function(){
+					self.fillVersion(Updater.getInfo());
+				}
+			});
+		} else {
+			// override cursor style from CSS
+			self.version_text.setProperty('style', 'cursor: auto');
+		}
+
+		if (!self.hide_about_dirs){
 			about_block.adopt(
 				new Element('dt[text=Directories]'),
 				new Element('dd', {'text': App.getOption('app_dir')}),

--- a/couchpotato/templates/index.html
+++ b/couchpotato/templates/index.html
@@ -89,6 +89,7 @@
 					'webui_feature': {
 						'hide_about_dirs' : {{ json_encode( Env.setting('hide_about_dirs', default=False, section = 'webui_feature', type='bool') ) }},
 						'hide_menuitem_update' : {{ json_encode( Env.setting('hide_menuitem_update', default=False, section = 'webui_feature', type='bool') ) }},
+						'hide_about_update' : {{ json_encode( Env.setting('hide_about_update', default=False, section = 'webui_feature', type='bool') ) }},
 					}
 				});
 			})


### PR DESCRIPTION
There is a link "Check for updates" on the tab "About" on the "Settings" page (it appears `onmouseover`)

This PR allow to hide this link depending on configuration of CP.

Sample of config:

```ini
[webui_feature]
hide_about_update = 1
```