### PR TITLE
Fix Transmission directory when not running local

### DIFF
--- a/couchpotato/core/downloaders/transmission.py
+++ b/couchpotato/core/downloaders/transmission.py
@@ -67,7 +67,8 @@ class Transmission(DownloaderBase):
         }
 
         if self.conf('directory'):
-            if os.path.isdir(self.conf('directory')):
+            host = cleanHost(self.conf('host')).rstrip('/').rsplit(':', 1)
+            if os.path.isdir(self.conf('directory')) or not (host[0] == '127.0.0.1' or host[0] == 'localhost'):
                 params['download-dir'] = self.conf('directory').rstrip(os.path.sep)
             else:
                 log.error('Download directory from Transmission settings: %s doesn\'t exist', self.conf('directory'))


### PR DESCRIPTION
### Description of what this fixes:

When using a remote Transmission host, the set directory check will fail. This fix will only check the directory if host is localhost or 127.0.0.1. This probably could be enhanced by some socket function to check if supplied host is local, but this seems to work fine.
