### PR TITLE
minor spelling correction for log clarity & searchability

### DIFF
--- a/couchpotato/core/plugins/release/main.py
+++ b/couchpotato/core/plugins/release/main.py
@@ -390,11 +390,11 @@ class Release(Plugin):
                 continue
 
             if rel['score'] < quality_custom.get('minimum_score'):
-                log.info('Ignored, score "%s" to low, need at least "%s": %s', (rel['score'], quality_custom.get('minimum_score'), rel['name']))
+                log.info('Ignored, score "%s" too low, need at least "%s": %s', (rel['score'], quality_custom.get('minimum_score'), rel['name']))
                 continue
 
             if rel['size'] <= 50:
-                log.info('Ignored, size "%sMB" to low: %s', (rel['size'], rel['name']))
+                log.info('Ignored, size "%sMB" too low: %s', (rel['size'], rel['name']))
                 continue
 
             if 'seeders' in rel and rel.get('seeders') < minimum_seeders:


### PR DESCRIPTION
### Description of what this fixes:
log output changed from: Ignored, score "-17" to low
log output changed to: Ignored, score "-17" too low

### Related issues:
...

