### PR TITLE
Fix start-stop script for DSM6 and beyond

### DIFF
--- a/init/synology
+++ b/init/synology
@@ -14,11 +14,10 @@ COUCHPOTATO="${INSTALL_DIR}/CouchPotato.py"
 CFG_FILE="${INSTALL_DIR}/var/settings.conf"
 PID_FILE="${INSTALL_DIR}/var/couchpotato.pid"
 LOG_FILE="${INSTALL_DIR}/var/logs/CouchPotato.log"
-DSM_MAJOR_VERSION=`cat /etc.defaults/VERSION | grep majorversion | grep -o [0-9]*`
 
 start_daemon ()
 {
-	if [ ${DSM_MAJOR_VERSION} -gt 5 ]; then
+    if [ `/bin/get_key_value /etc.defaults/VERSION majorversion` -ge 6 ]; then
  		sudo -u ${RUNAS} PATH=${PATH} ${PYTHON} ${COUCHPOTATO} --daemon --pid_file ${PID_FILE} --config ${CFG_FILE}
  	else
  		su ${RUNAS} -c "PATH=${PATH} ${PYTHON} ${COUCHPOTATO} --daemon --pid_file ${PID_FILE} --config ${CFG_FILE}"

--- a/init/synology
+++ b/init/synology
@@ -14,11 +14,15 @@ COUCHPOTATO="${INSTALL_DIR}/CouchPotato.py"
 CFG_FILE="${INSTALL_DIR}/var/settings.conf"
 PID_FILE="${INSTALL_DIR}/var/couchpotato.pid"
 LOG_FILE="${INSTALL_DIR}/var/logs/CouchPotato.log"
+DSM_MAJOR_VERSION=`cat /etc.defaults/VERSION | grep majorversion | grep -o [0-9]*`
 
-
-start_daemon()
+start_daemon ()
 {
-su ${RUNAS} -c "PATH=${PATH} ${PYTHON} ${COUCHPOTATO} --daemon --pid_file ${PID_FILE} --config ${CFG_FILE}"
+	if [ ${DSM_MAJOR_VERSION} -gt 5 ]; then
+ 		sudo -u ${RUNAS} PATH=${PATH} ${PYTHON} ${COUCHPOTATO} --daemon --pid_file ${PID_FILE} --config ${CFG_FILE}
+ 	else
+ 		su ${RUNAS} -c "PATH=${PATH} ${PYTHON} ${COUCHPOTATO} --daemon --pid_file ${PID_FILE} --config ${CFG_FILE}"
+ 	fi
 }
 
 stop_daemon()
@@ -31,44 +35,45 @@ stop_daemon()
 daemon_status()
 {
     if [ -f ${PID_FILE} ] && [ -d /proc/`cat ${PID_FILE}` ]; then
-return 0
+		return 0
     fi
-return 1
+	return 1
 }
 
 wait_for_status()
 {
     counter=$2
     while [ ${counter} -gt 0 ]; do
-daemon_status
+		daemon_status
         [ $? -eq $1 ] && break
-let counter=counter-1
+		let counter=counter-1
         sleep 1
     done
 }
+
 case $1 in
     start)
         if daemon_status; then
-echo ${DNAME} is already running
+			echo ${DNAME} is already running
         else
-echo Starting ${DNAME} ...
+			echo Starting ${DNAME} ...
             start_daemon
         fi
         ;;
     stop)
         if daemon_status; then
-echo Stopping ${DNAME} ...
+			echo Stopping ${DNAME} ...
             stop_daemon
         else
-echo ${DNAME} is not running
+			echo ${DNAME} is not running
         fi
         ;;
     status)
         if daemon_status; then
-echo ${DNAME} is running
+			echo ${DNAME} is running
             exit 0
         else
-echo ${DNAME} is not running
+			echo ${DNAME} is not running
             exit 1
         fi
         ;;


### PR DESCRIPTION
### Description of what this fixes:
Fixes start-stop script for Synology users with DSM version 6.0 or higher. Also made it backwards compatible for older versions.

### Related issues:
https://github.com/CouchPotato/CouchPotatoServer/issues/6249
https://github.com/SynoCommunity/spksrc/issues/2104

