### PR TITLE
fix(providers/torrent/alpharatio): address the right index of the arr…

### DIFF
--- a/couchpotato/core/media/_base/providers/torrent/alpharatio.py
+++ b/couchpotato/core/media/_base/providers/torrent/alpharatio.py
@@ -42,7 +42,7 @@ class Base(TorrentProvider):
                     link = result.find('a', attrs = {'dir': 'ltr'})
                     url = result.find('a', attrs = {'title': 'Download'})
                     tds = result.find_all('td')
-                    size = tds[4].contents[0].strip('\n ')
+                    size = tds[5].contents[0].strip('\n ')
 
                     results.append({
                         'id': link['href'].replace('torrents.php?id=', '').split('&')[0],


### PR DESCRIPTION
### Description of what this fixes:
Small bug in alphratio tracker search script

### Related issues:
#5073 #4939 

…ay of TD elements

This is a stopgap. There should be a nice way to find the size (regex would be better).