### PR TITLE
Automatic account disabling on login failure for all torrent providers

### DIFF
--- a/couchpotato/core/media/_base/providers/torrent/alpharatio.py
+++ b/couchpotato/core/media/_base/providers/torrent/alpharatio.py
@@ -22,6 +22,7 @@ class Base(TorrentProvider):
     }
 
     http_time_between_calls = 1  # Seconds
+    login_fail_msg = '</span> attempts remaining.'
 
     def _search(self, media, quality, results):
 

--- a/couchpotato/core/media/_base/providers/torrent/awesomehd.py
+++ b/couchpotato/core/media/_base/providers/torrent/awesomehd.py
@@ -19,12 +19,17 @@ class Base(TorrentProvider):
         'download': 'https://awesome-hd.me/torrents.php?action=download&id=%s&authkey=%s&torrent_pass=%s',
     }
     http_time_between_calls = 1
+    login_fail_msg = 'Please check that you provided a valid API Key, username, and action.'
 
     def _search(self, movie, quality, results):
 
         data = self.getHTMLData(self.urls['search'] % (self.conf('passkey'), getIdentifier(movie), self.conf('only_internal')))
 
         if data:
+            if self.login_fail_msg in data:
+                self.disableAccount()
+                return
+
             try:
                 soup = BeautifulSoup(data)
 

--- a/couchpotato/core/media/_base/providers/torrent/bithdtv.py
+++ b/couchpotato/core/media/_base/providers/torrent/bithdtv.py
@@ -22,6 +22,7 @@ class Base(TorrentProvider):
 
     # Searches for movies only - BiT-HDTV's subcategory and resolution search filters appear to be broken
     http_time_between_calls = 1  # Seconds
+    login_fail_msg = 'Username or password incorrect.'
 
     def _search(self, media, quality, results):
 

--- a/couchpotato/core/media/_base/providers/torrent/bitsoup.py
+++ b/couchpotato/core/media/_base/providers/torrent/bitsoup.py
@@ -20,6 +20,7 @@ class Base(TorrentProvider):
     }
 
     http_time_between_calls = 1  # Seconds
+    login_fail_msg = 'Login failed!'
     only_tables_tags = SoupStrainer('table')
 
     torrent_name_cell = 1

--- a/couchpotato/core/media/_base/providers/torrent/hd4free.py
+++ b/couchpotato/core/media/_base/providers/torrent/hd4free.py
@@ -20,11 +20,16 @@ class Base(TorrentProvider):
     }
 
     http_time_between_calls = 1  # Seconds
+    login_fail_msg = 'Your apikey is not valid! Go to HD4Free and reset your apikey.'
 
     def _search(self, movie, quality, results):
         data = self.getJsonData(self.urls['search'] % (self.conf('apikey'), self.conf('username'), getIdentifier(movie), self.conf('internal_only')))
 
         if data:
+            if self.login_fail_msg in data['error']: # Check for login failure
+                self.disableAccount()
+                return
+
             try:
                 #for result in data[]:
                 for key, result in data.iteritems():

--- a/couchpotato/core/media/_base/providers/torrent/hdbits.py
+++ b/couchpotato/core/media/_base/providers/torrent/hdbits.py
@@ -20,6 +20,7 @@ class Base(TorrentProvider):
     }
 
     http_time_between_calls = 1  # Seconds
+    login_fail_msg = 'Invalid authentication credentials'
 
     def _post_query(self, **params):
 
@@ -37,6 +38,9 @@ class Base(TorrentProvider):
 
             if result:
                 if result['status'] != 0:
+                    if self.login_fail_msg in result['message']: # Check for login failure
+                        self.disableAccount()
+                        return
                     log.error('Error searching hdbits: %s' % result['message'])
                 else:
                     return result['data']

--- a/couchpotato/core/media/_base/providers/torrent/ilovetorrents.py
+++ b/couchpotato/core/media/_base/providers/torrent/ilovetorrents.py
@@ -22,6 +22,8 @@ class Base(TorrentProvider):
         'login_check': 'https://www.ilovetorrents.me'
     }
 
+    login_fail_msg = 'Login failed!'
+
     cat_ids = [
         (['80'], ['720p', '1080p']),
         (['41'], ['brrip']),

--- a/couchpotato/core/media/_base/providers/torrent/iptorrents.py
+++ b/couchpotato/core/media/_base/providers/torrent/iptorrents.py
@@ -22,6 +22,7 @@ class Base(TorrentProvider):
     }
 
     http_time_between_calls = 1  # Seconds
+    login_fail_msg = 'Invalid username and password combination'
     cat_backup_id = None
 
     def buildUrl(self, title, media, quality):

--- a/couchpotato/core/media/_base/providers/torrent/morethantv.py
+++ b/couchpotato/core/media/_base/providers/torrent/morethantv.py
@@ -23,6 +23,7 @@ class Base(TorrentProvider):
     }
 
     http_time_between_calls = 1  # Seconds
+    login_fail_msg = 'You entered an invalid password.'
 
     def _searchOnTitle(self, title, movie, quality, results):
 

--- a/couchpotato/core/media/_base/providers/torrent/sceneaccess.py
+++ b/couchpotato/core/media/_base/providers/torrent/sceneaccess.py
@@ -23,6 +23,7 @@ class Base(TorrentProvider):
     }
 
     http_time_between_calls = 1  # Seconds
+    login_fail_msg = 'Username or password incorrect'
 
     def _searchOnTitle(self, title, media, quality, results):
 

--- a/couchpotato/core/media/_base/providers/torrent/scenetime.py
+++ b/couchpotato/core/media/_base/providers/torrent/scenetime.py
@@ -29,6 +29,7 @@ class Base(TorrentProvider):
     ]
 
     http_time_between_calls = 1  # Seconds
+    login_fail_msg = 'Username or password incorrect'
     cat_backup_id = None
 
     def _searchOnTitle(self, title, movie, quality, results):
@@ -47,7 +48,7 @@ class Base(TorrentProvider):
                     return
 
                 entries = result_table.find_all('tr')
-                
+
                 for result in entries[1:]:
                     cells = result.find_all('td')
                     link = result.find('a', attrs = {'class': 'index'})
@@ -57,9 +58,9 @@ class Base(TorrentProvider):
                     name_row = cells[1].contents[0]
                     name = name_row.getText()
                     seeders_row = cells[6].contents[0]
-                    seeders = seeders_row.getText()		     
-                    
-                    
+                    seeders = seeders_row.getText()
+
+
                     results.append({
                         'id': torrent_id,
                         'name': name,
@@ -67,7 +68,7 @@ class Base(TorrentProvider):
                         'detail_url': self.urls['detail'] % torrent_id,
                         'size': size,
                         'seeders': seeders,
-                    })		    
+                    })
 
             except:
                 log.error('Failed to parsing %s: %s', (self.getName(), traceback.format_exc()))

--- a/couchpotato/core/media/_base/providers/torrent/torrentbytes.py
+++ b/couchpotato/core/media/_base/providers/torrent/torrentbytes.py
@@ -32,6 +32,7 @@ class Base(TorrentProvider):
     ]
 
     http_time_between_calls = 1  # Seconds
+    login_fail_msg = 'Username or password incorrect'
     cat_backup_id = None
 
     def _searchOnTitle(self, title, movie, quality, results):

--- a/couchpotato/core/media/_base/providers/torrent/torrentleech.py
+++ b/couchpotato/core/media/_base/providers/torrent/torrentleech.py
@@ -22,6 +22,7 @@ class Base(TorrentProvider):
     }
 
     http_time_between_calls = 1  # Seconds
+    login_fail_msg = 'Invalid Username/password combination!'
     cat_backup_id = None
 
     def _searchOnTitle(self, title, media, quality, results):

--- a/couchpotato/core/media/_base/providers/torrent/torrentshack.py
+++ b/couchpotato/core/media/_base/providers/torrent/torrentshack.py
@@ -22,6 +22,7 @@ class Base(TorrentProvider):
     }
 
     http_time_between_calls = 1  # Seconds
+    login_fail_msg = 'You entered an invalid'
 
     def _search(self, media, quality, results):
 


### PR DESCRIPTION
### Description of what this fixes:
All torrent providers now automatically disable themselves on authentication failure. (except TorrentDay, which I plan to work on later)

fixes #2232 
fixes #6228 
fixes #5033

### Related issues:
This does not work with TorrentDay.