### PR TITLE
Kodi cosmetics, rename XBMC references to Kodi

### DIFF
--- a/couchpotato/core/media/movie/providers/metadata/xbmc.py
+++ b/couchpotato/core/media/movie/providers/metadata/xbmc.py
@@ -232,8 +232,8 @@ config = [{
             'tab': 'renamer',
             'subtab': 'metadata',
             'name': 'xbmc_metadata',
-            'label': 'XBMC',
-            'description': 'Enable metadata XBMC can understand',
+            'label': 'Kodi',
+            'description': 'Enable metadata Kodi can understand',
             'options': [
                 {
                     'name': 'meta_enabled',

--- a/couchpotato/core/notifications/xbmc.py
+++ b/couchpotato/core/notifications/xbmc.py
@@ -62,7 +62,7 @@ class XBMC(Notification):
                     if result.get('result') and result['result'] == 'OK':
                         successful += 1
                     elif result.get('error'):
-                        log.error('XBMC error; %s: %s (%s)', (result['id'], result['error']['message'], result['error']['code']))
+                        log.error('Kodi error; %s: %s (%s)', (result['id'], result['error']['message'], result['error']['code']))
 
             except:
                 log.error('Failed parsing results: %s', traceback.format_exc())
@@ -73,7 +73,7 @@ class XBMC(Notification):
 
         success = False
 
-        # XBMC JSON-RPC version request
+        # Kodi JSON-RPC version request
         response = self.request(host, [
             ('JSONRPC.Version', None, {})
         ])
@@ -100,15 +100,15 @@ class XBMC(Notification):
                         break
 
             elif result.get('result') and type(result['result']['version']).__name__ == 'dict':
-                # XBMC JSON-RPC v6 returns an array object containing
+                # Kodi JSON-RPC v6 returns an array object containing
                 # major, minor and patch number
                 xbmc_rpc_version = str(result['result']['version']['major'])
                 xbmc_rpc_version += '.' + str(result['result']['version']['minor'])
                 xbmc_rpc_version += '.' + str(result['result']['version']['patch'])
 
-                log.debug('Kodie JSON-RPC Version: %s', xbmc_rpc_version)
+                log.debug('Kodi JSON-RPC Version: %s', xbmc_rpc_version)
 
-                # ok, XBMC version is supported
+                # ok, Kodi version is supported
                 self.use_json_notifications[host] = True
 
                 # send the text message
@@ -122,7 +122,7 @@ class XBMC(Notification):
                         log.error('Kodi error; %s: %s (%s)', (r['id'], r['error']['message'], r['error']['code']))
                         break
 
-            # error getting version info (we do have contact with XBMC though)
+            # error getting version info (we do have contact with Kodi though)
             elif result.get('error'):
                 log.error('Kodi error; %s: %s (%s)', (result['id'], result['error']['message'], result['error']['code']))
 

--- a/couchpotato/core/plugins/renamer.py
+++ b/couchpotato/core/plugins/renamer.py
@@ -1381,7 +1381,7 @@ config = [{
                     'advanced': True,
                     'name': 'unrar_modify_date',
                     'type': 'bool',
-                    'description': ('Set modify date of unrar-ed files to the rar-file\'s date.', 'This will allow XBMC to recognize extracted files as recently added even if the movie was released some time ago.'),
+                    'description': ('Set modify date of unrar-ed files to the rar-file\'s date.', 'This will allow Kodi to recognize extracted files as recently added even if the movie was released some time ago.'),
                     'default': False,
                 },
                 {


### PR DESCRIPTION
### Description of what this fixes:

Changes to web interface labels and other references of XBMC to Kodi. Mainly cosmetic. No changes made to classes or functions. Mentions of XBMC versions below 14 i.e. comments have been left alone as these are technically correct.

### Related issues:

None

