### PR TITLE
Fix for [SSL: CERTIFICATE_VERIFY_FAILED]

### DIFF
--- a/couchpotato/core/downloaders/nzbget.py
+++ b/couchpotato/core/downloaders/nzbget.py
@@ -1,6 +1,7 @@
 from base64 import standard_b64encode
 from datetime import timedelta
 import re
+import sys
 import shutil
 import socket
 import traceback
@@ -11,6 +12,9 @@ from couchpotato.core.helpers.encoding import ss, sp
 from couchpotato.core.helpers.variable import tryInt, md5, cleanHost
 from couchpotato.core.logger import CPLog
 
+if sys.version_info >= (2, 7, 9):
+        import ssl
+        ssl._create_default_https_context = ssl._create_unverified_context
 
 log = CPLog(__name__)
 


### PR DESCRIPTION
### Description of what this fixes:
...

### Related issues:
...

Starting in version 2.7.9 of python some SSL certs will cause an error in python and will cause CP to not connect to nzbget.

See issue #4811 (https://github.com/RuudBurger/CouchPotatoServer/issues/4811)

This will fix such error as described by PEP 476 by python (https://www.python.org/dev/peps/pep-0476/#opting-out)