### PR TITLE
Improve PassThePopcorn provider

### DIFF
--- a/couchpotato/core/media/_base/providers/torrent/passthepopcorn.py
+++ b/couchpotato/core/media/_base/providers/torrent/passthepopcorn.py
@@ -58,7 +58,7 @@ class Base(TorrentProvider):
                 log.debug('Movie %s (%s) has %d torrents', (ptpmovie['Title'], ptpmovie['Year'], len(ptpmovie['Torrents'])))
                 for torrent in ptpmovie['Torrents']:
                     torrent_id = tryInt(torrent['Id'])
-                    torrentdesc = '%s %s %s' % (torrent['Resolution'], torrent['Source'], torrent['Codec'])
+                    torrentdesc = ''
                     torrentscore = 0
 
                     if 'GoldenPopcorn' in torrent and torrent['GoldenPopcorn']:
@@ -77,7 +77,7 @@ class Base(TorrentProvider):
                         torrentdesc += self.htmlToASCII(' %s' % torrent['RemasterTitle'])
 
                     torrentdesc += ' (%s)' % quality_id
-                    torrent_name = re.sub('[^A-Za-z0-9\-_ \(\).]+', '', '%s (%s) - %s' % (movie_title, ptpmovie['Year'], torrentdesc))
+                    torrent_name = torrent['ReleaseName'] + ' - %s' % torrentdesc
 
                     def extra_check(item):
                         return self.torrentMeetsQualitySpec(item, quality_id)
@@ -205,7 +205,7 @@ config = [{
             'tab': 'searcher',
             'list': 'torrent_providers',
             'name': 'PassThePopcorn',
-            'description': '<a href="https://passthepopcorn.me" target="_blank">PassThePopcorn.me</a>',
+            'description': '<a href="https://passthepopcorn.me">PassThePopcorn.me</a>',
             'wizard': True,
             'icon': 'iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAARklEQVQoz2NgIAP8BwMiGWRpIN1JNWn/t6T9f5'
                     '32+W8GkNt7vzz9UkfarZVpb68BuWlbnqW1nU7L2DMx7eCoBlpqGOppCQB83zIgIg+wWQAAAABJRU5ErkJggg==',

--- a/couchpotato/core/media/_base/providers/torrent/passthepopcorn.py
+++ b/couchpotato/core/media/_base/providers/torrent/passthepopcorn.py
@@ -76,7 +76,6 @@ class Base(TorrentProvider):
                     if 'RemasterTitle' in torrent and torrent['RemasterTitle']:
                         torrentdesc += self.htmlToASCII(' %s' % torrent['RemasterTitle'])
 
-                    torrentdesc += ' (%s)' % quality_id
                     torrent_name = torrent['ReleaseName'] + ' - %s' % torrentdesc
 
                     def extra_check(item):


### PR DESCRIPTION
### Description of what this fixes:
It's smarter to parse the release name rather than the movie title. This makes it possible to customize the search results (block specific release groups for example). I removed the resolution, source and codec parameters from torrentdesc as it's already included in the release name. 

### Related issues:
...

