### PR TITLE
Change log level when checking NZBGet status

### DIFF
--- a/couchpotato/core/downloaders/nzbget.py
+++ b/couchpotato/core/downloaders/nzbget.py
@@ -122,7 +122,7 @@ class NZBGet(DownloaderBase):
         rpc = self.getRPC()
 
         try:
-            if rpc.writelog('INFO', 'CouchPotato connected to check status'):
+            if rpc.writelog('DETAIL', 'CouchPotato connected to check status'):
                 log.debug('Successfully connected to NZBGet')
             else:
                 log.info('Successfully connected to NZBGet, but unable to send a message')


### PR DESCRIPTION
### Description of what this fixes:
CouchPotato writes `CouchPotato connected to check status` to NZBGet log every minute. `DETAIL` level is hidden in NZBGet by default.

### Related issues:
#6423 