### PR TITLE
Fixing UnicodeEncodeError: 'ascii' codec can't encode character Error

### DIFF
--- a/couchpotato/core/notifications/telegrambot.py
+++ b/couchpotato/core/notifications/telegrambot.py
@@ -3,6 +3,10 @@ from couchpotato.core.logger import CPLog
 from couchpotato.core.notifications.base import Notification
 import requests
 import six
+#Fix ascii codec encode errors
+import sys
+reload(sys)
+sys.setdefaultencoding("utf-8")
 
 log = CPLog(__name__)
 


### PR DESCRIPTION
### Description of what this fixes:
This fix ascii codec error on telegram notifications

05-29 23:39:24 ERROR [   couchpotato.core.event] Error in event "movie.snatched", that wasn't caught: Traceback (most recent call last):
  File "/opt/couchpotato/couchpotato/core/event.py", line 15, in runHandler
    return handler(*args, **kwargs)
  File "/opt/couchpotato/couchpotato/core/notifications/base.py", line 41, in notify
    return self._notify(message = message, data = data if data else group, listener = listener)
  File "/opt/couchpotato/couchpotato/core/notifications/base.py", line 50, in _notify
    return self.notify(*args, **kwargs)
  File "/opt/couchpotato/couchpotato/core/notifications/telegrambot.py", line 27, in notify
    message = '{0}\n{1}'.format(message, url)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xf1' in position 53: ordinal not in range(128)
encoding=UTF-8 debug=False args=['--quiet', '--daemon', '--pid_file=/var/run/couchpotato.pid', '--data_dir=/var/couchpotato'] app_dir=/opt/couchpotato data_dir=/var/couchpotato desktop=None options=Namespace(config_file='/var/couchpotato/settings.conf', console_log=False, daemon=True, data_dir='/var/couchpotato', debug=False, pid_file='/var/run/couchpotato.pid', quiet=True)


### Related issues:
...

