### PR TITLE
Fixes #6489 - Was comparing string against dictionary key without che…

### DIFF
--- a/couchpotato/core/media/_base/providers/torrent/hd4free.py
+++ b/couchpotato/core/media/_base/providers/torrent/hd4free.py
@@ -25,10 +25,11 @@ class Base(TorrentProvider):
     def _search(self, movie, quality, results):
         data = self.getJsonData(self.urls['search'] % (self.conf('apikey'), self.conf('username'), getIdentifier(movie), self.conf('internal_only')))
 
-        if data:
-            if self.login_fail_msg in data['error']: # Check for login failure
-                self.disableAccount()
-                return
+        if 'error' in data:
+            if data:
+                if self.login_fail_msg in data['error']: # Check for login failure
+                    self.disableAccount()
+                    return
 
             try:
                 #for result in data[]:


### PR DESCRIPTION
### Description of what this fixes:
Was checking to see if a string existed in a dictionary key without making sure the key existed first.  Resolved.

### Related issues:
Resolves #6489 