### PR TITLE
Always select the first custom category as default

### DIFF
--- a/couchpotato/core/media/movie/_base/main.py
+++ b/couchpotato/core/media/movie/_base/main.py
@@ -87,11 +87,21 @@ class MovieBase(MovieTypeBase):
         # Set default title
         def_title = self.getDefaultTitle(info)
 
-        # Default profile and category
+        # Default profile
         default_profile = {}
         if (not params.get('profile_id') and status != 'done') or params.get('ignore_previous', False):
             default_profile = fireEvent('profile.default', single = True)
+
+        # Set category
         cat_id = params.get('category_id')
+        if cat_id == '-1':
+            cat_id = None
+        elif (cat_id is None or len(cat_id) == 0) and (status != 'done' or params.get('ignore_previous', False)):
+            default_category = fireEvent('category.default', single = True)
+            if default_category is not None:
+                cat_id = default_category.get('_id')
+            else:
+                cat_id = None
 
         try:
             db = get_db()
@@ -105,7 +115,7 @@ class MovieBase(MovieTypeBase):
                 },
                 'status': status if status else 'active',
                 'profile_id': params.get('profile_id') or default_profile.get('_id'),
-                'category_id': cat_id if cat_id is not None and len(cat_id) > 0 and cat_id != '-1' else None,
+                'category_id': cat_id,
             }
 
             # Update movie info

--- a/couchpotato/core/media/movie/_base/static/search.js
+++ b/couchpotato/core/media/movie/_base/static/search.js
@@ -199,6 +199,7 @@ var BlockSearchMovieItem = new Class({
 						'text': category.data.label
 					}).inject(self.category_select);
 				});
+				self.category_select.selectedIndex = 1;
 			}
 
 			// Fill profiles

--- a/couchpotato/core/plugins/category/main.py
+++ b/couchpotato/core/plugins/category/main.py
@@ -32,6 +32,7 @@ class CategoryPlugin(Plugin):
         })
 
         addEvent('category.all', self.all)
+        addEvent('category.default', self.default)
 
     def allView(self, **kwargs):
 
@@ -46,6 +47,10 @@ class CategoryPlugin(Plugin):
         categories = db.all('category', with_doc = True)
 
         return [x['doc'] for x in categories]
+
+    def default(self):
+        db = get_db()
+        return list(db.all('category', limit = 1, with_doc = True))[0]['doc']
 
     def save(self, **kwargs):
 

--- a/couchpotato/core/plugins/category/static/category.js
+++ b/couchpotato/core/plugins/category/static/category.js
@@ -115,7 +115,7 @@ var CategoryListBase = new Class({
 				new Element('label[text=Order]'),
 				category_list = new Element('ul'),
 				new Element('p.formHint', {
-					'html': 'Change the order the categories are in the dropdown list.'
+					'html': 'Change the order the categories are in the dropdown list, first will always be the default.'
 				})
 			)
 		).inject(self.content);

--- a/couchpotato/static/scripts/combined.plugins.min.js
+++ b/couchpotato/static/scripts/combined.plugins.min.js
@@ -2193,6 +2193,7 @@ var BlockSearchMovieItem = new Class({
                         text: category.data.label
                     }).inject(self.category_select);
                 });
+                self.category_select.selectedIndex = 1;
             }
             var profiles = Quality.getActiveProfiles();
             if (profiles.length == 1) self.profile_select.hide();
@@ -2749,7 +2750,7 @@ var CategoryListBase = new Class({
         self.settings.createGroup({
             label: "Category ordering"
         }).adopt(new Element(".ctrlHolder#category_ordering").adopt(new Element("label[text=Order]"), category_list = new Element("ul"), new Element("p.formHint", {
-            html: "Change the order the categories are in the dropdown list."
+            html: "Change the order the categories are in the dropdown list, first will always be the default."
         }))).inject(self.content);
         Array.each(self.categories, function(category) {
             new Element("li", {


### PR DESCRIPTION
This fixes #3142, a 2 year old issue of mine. At that time the description actually stated `First one will be default.`, but someone removed that.

This change brings some advantages over the current code (`None` as default category):
- Foreign users can manage multiple languages, f.e. one can force German language by default but can select other languages when needed
- One can disable AC3 releases by default, but drop that limit when needed

Theoretically one could always select their default category manually, but this doesn't work for the automations. Also it's a pain in the ass to do that every time you search.

The downsite is that all users that use categories now will have their first category selected as default.
However they can restore the old behaviour by adding an empty category as their first category.