### PR TITLE
BITHDTV download URL fix

### DIFF
--- a/couchpotato/core/media/_base/providers/torrent/bithdtv.py
+++ b/couchpotato/core/media/_base/providers/torrent/bithdtv.py
@@ -18,6 +18,7 @@ class Base(TorrentProvider):
         'login_check': 'https://www.bit-hdtv.com/messages.php',
         'detail': 'https://www.bit-hdtv.com/details.php?id=%s',
         'search': 'https://www.bit-hdtv.com/torrents.php?',
+        'download': 'https://www.bit-hdtv.com/download.php?id=%s',
     }
 
     # Searches for movies only - BiT-HDTV's subcategory and resolution search filters appear to be broken
@@ -50,12 +51,12 @@ class Base(TorrentProvider):
 
                     cells = result.find_all('td')
                     link = cells[2].find('a')
-                    torrent_id = link['href'].replace('/details.php?id=', '')
+                    torrent_id = link['href'].split('id=')[1]
 
                     results.append({
                         'id': torrent_id,
                         'name': link.contents[0].get_text(),
-                        'url': cells[0].find('a')['href'],
+                        'url': self.urls['download'] % torrent_id,
                         'detail_url': self.urls['detail'] % torrent_id,
                         'size': self.parseSize(cells[6].get_text()),
                         'seeders': tryInt(cells[8].string),


### PR DESCRIPTION
### Description of what this fixes:
Bit-HDTV announced on their forum they changed the format of the url to download the .torrent files which prevents CouchPotato from referencing them.

Old format : /download.php?/123456/dl.torrent
New format : /download.php?id=123456

This also fixes the details link being broken due to incorrect parsing of the torrent_id.

### Related issues:
https://github.com/CouchPotato/CouchPotatoServer/issues/6498
https://github.com/CouchPotato/CouchPotatoServer/issues/6532
