### PR TITLE
Update for qBittorrent 3.3.5

### DIFF
--- a/couchpotato/core/downloaders/qbittorrent_.py
+++ b/couchpotato/core/downloaders/qbittorrent_.py
@@ -24,9 +24,9 @@ class qBittorrent(DownloaderBase):
     def __init__(self):
         super(qBittorrent, self).__init__()
 
-    def connect(self, reconnect = False):
-        if not reconnect and self.qb is not None:
-            return self.qb
+    def connect(self):
+        if self.qb is not None:
+            self.qb.logout
 
         url = cleanHost(self.conf('host'), protocol = True, ssl = False)
         
@@ -43,7 +43,7 @@ class qBittorrent(DownloaderBase):
         :return: bool
         """
         
-        self.connect(True)
+        self.connect()
         
         return self.qb._is_authenticated
 


### PR DESCRIPTION
This should fix labels being added in qBittorrent 3.3.5. They changed labels to categories resulting in a change to the api. This should maintain backward compatibility with labels in previous versions. I tested with 3.3.4 and 3.3.5 on Windows 10 x64. When switching between versions I noticed that CouchPotato
did not re-authenticate with qBittorrent without restarting CouchPotato which I tried to fixed as well.
...
