### PR TITLE
Check for error existence first

### DIFF
--- a/couchpotato/core/media/_base/providers/torrent/hd4free.py
+++ b/couchpotato/core/media/_base/providers/torrent/hd4free.py
@@ -24,9 +24,9 @@ class Base(TorrentProvider):
 
     def _search(self, movie, quality, results):
         data = self.getJsonData(self.urls['search'] % (self.conf('apikey'), self.conf('username'), getIdentifier(movie), self.conf('internal_only')))
-
         if data:
-            if self.login_fail_msg in data['error']: # Check for login failure
+            
+            if 'error' in data and self.login_fail_msg in data['error']: # Check for login failure
                 self.disableAccount()
                 return
 


### PR DESCRIPTION
### Description of what this fixes:

Getting an error whenever searching HD4free as the API no longer returns an error element if there is no error.  This simply checks for it's existence **before** accessing it, avoiding a KeyError.

### Related issues:

None that I could find off a search for the trace I was seeing.

