### PR TITLE
Don't throw out good data when there is no error

### DIFF
--- a/couchpotato/core/media/_base/providers/torrent/hd4free.py
+++ b/couchpotato/core/media/_base/providers/torrent/hd4free.py
@@ -1,3 +1,4 @@
+
 import re
 import json
 import traceback
@@ -26,8 +27,11 @@ class Base(TorrentProvider):
         data = self.getJsonData(self.urls['search'] % (self.conf('apikey'), self.conf('username'), getIdentifier(movie), self.conf('internal_only')))
 
         if data:
-            if error in data and self.login_fail_msg in data['error']: # Check for login failure
-                self.disableAccount()
+            if 'error' in data:
+                if self.login_fail_msg in data['error']: # Check for login failure
+                    self.disableAccount()
+                else:
+                    log.warn('%s return an error (possible rate limit): %s', (self.getName(), data['error']))
                 return
 
             try:

--- a/couchpotato/core/media/_base/providers/torrent/hd4free.py
+++ b/couchpotato/core/media/_base/providers/torrent/hd4free.py
@@ -31,7 +31,7 @@ class Base(TorrentProvider):
                 if self.login_fail_msg in data['error']: # Check for login failure
                     self.disableAccount()
                 else:
-                    log.warn('%s return an error (possible rate limit): %s', (self.getName(), data['error']))
+                    log.error('%s returned an error (possible rate limit): %s', (self.getName(), data['error']))
                 return
 
             try:

--- a/couchpotato/core/media/_base/providers/torrent/hd4free.py
+++ b/couchpotato/core/media/_base/providers/torrent/hd4free.py
@@ -25,11 +25,10 @@ class Base(TorrentProvider):
     def _search(self, movie, quality, results):
         data = self.getJsonData(self.urls['search'] % (self.conf('apikey'), self.conf('username'), getIdentifier(movie), self.conf('internal_only')))
 
-        if 'error' in data:
-            if data:
-                if self.login_fail_msg in data['error']: # Check for login failure
-                    self.disableAccount()
-                    return
+        if data:
+            if error in data and self.login_fail_msg in data['error']: # Check for login failure
+                self.disableAccount()
+                return
 
             try:
                 #for result in data[]:


### PR DESCRIPTION
### Description of what this fixes:

Based on playing with the HD4Free API, it looks like the 'error' property is only added if there is an error
So instead of ignoring all the data, just look for the property if/when we need it.

### Related issues:

#6489 & 8569ef7dbbc35fd089637966cfce2ac82e2eed7d
