### PR TITLE
Fix for HD4Free not returning 'error' when there is no error...

### DIFF
--- a/couchpotato/core/media/_base/providers/torrent/hd4free.py
+++ b/couchpotato/core/media/_base/providers/torrent/hd4free.py
@@ -26,8 +26,9 @@ class Base(TorrentProvider):
         data = self.getJsonData(self.urls['search'] % (self.conf('apikey'), self.conf('username'), getIdentifier(movie), self.conf('internal_only')))
 
         if data:
-            if self.login_fail_msg in data['error']: # Check for login failure
-                self.disableAccount()
+            if 'error' in data:
+                if self.login_fail_msg in data['error']: # Check for login failure
+                    self.disableAccount()
                 return
 
             try:


### PR DESCRIPTION
### Description of what this fixes:
I'm not sure if the HD4Free API used to always return an 'error' element in it's search response, but that doesn't appear to be the case anymore. The current HD4Free provider is broken because it fails to find 'error' when it searches for the login_fail_msg. This fix simply checks if 'error' exists in data before checking for the login_fail_msg.

### Related issues:
I think this was a change to the HD4Free API so I can't see there being any related issues.