### PR TITLE
Fix Alpha Ratio searching with comma

### DIFF
--- a/couchpotato/core/media/_base/providers/torrent/alpharatio.py
+++ b/couchpotato/core/media/_base/providers/torrent/alpharatio.py
@@ -27,7 +27,8 @@ class Base(TorrentProvider):
     def _search(self, media, quality, results):
 
         url = self.urls['search'] % self.buildUrl(media, quality)
-        data = self.getHTMLData(url)
+        cleaned_url = url.replace('%3A', '')
+        data = self.getHTMLData(cleaned_url)
 
         if data:
             html = BeautifulSoup(data)


### PR DESCRIPTION
### Description of what this fixes:
Fixes searching with Alpha Ratio tracker. `:` kills their search engine and makes it return nothing at all. This simple solution by @lemosm works around that issue.

I'm unsure on the global direction, might be better to catch it in the `buildUrl` method, since a `:` sign should not be searched anyway IMHO.

### Related issues:
#6636

