### PR TITLE
update qbittorrent.py for native magnet support

### DIFF
--- a/couchpotato/core/downloaders/qbittorrent_.py
+++ b/couchpotato/core/downloaders/qbittorrent_.py
@@ -2,6 +2,7 @@ from base64 import b16encode, b32decode
 from hashlib import sha1
 from datetime import timedelta
 import os
+import re
 
 from bencode import bencode, bdecode
 from couchpotato.core._base.downloader.main import DownloaderBase, ReleaseDownloadList
@@ -71,30 +72,34 @@ class qBittorrent(DownloaderBase):
             log.error('Failed sending torrent, no data')
             return False
 
-
         if data.get('protocol') == 'torrent_magnet':
-            filedata = self.magnetToTorrent(data.get('url'))
+            # Send request to qBittorrent directly as a magnet
+            try:
+                self.qb.download_from_link(data.get('url'), label=self.conf('label'))
+                torrent_hash = re.findall('urn:btih:([\w]{32,40})', data.get('url'))[0].upper()
+                log.info('Torrent [magnet] sent to QBittorrent successfully.')
+                return self.downloadReturnId(torrent_hash)
 
-            if filedata is False:
+            except Exception as e:
+                log.error('Failed to send torrent to qBittorrent: %s', e)
                 return False
 
-            data['protocol'] = 'torrent'
+        if data.get('protocol')  == 'torrent':
+             info = bdecode(filedata)["info"]
+             torrent_hash = sha1(bencode(info)).hexdigest()
 
-        info = bdecode(filedata)["info"]
-        torrent_hash = sha1(bencode(info)).hexdigest()
+             # Convert base 32 to hex
+             if len(torrent_hash) == 32:
+                torrent_hash = b16encode(b32decode(torrent_hash))
 
-        # Convert base 32 to hex
-        if len(torrent_hash) == 32:
-            torrent_hash = b16encode(b32decode(torrent_hash))
-
-        # Send request to qBittorrent
-        try:
-            self.qb.download_from_file(filedata, label=self.conf('label'))
-
-            return self.downloadReturnId(torrent_hash)
-        except Exception as e:
-            log.error('Failed to send torrent to qBittorrent: %s', e)
-            return False
+             # Send request to qBittorrent
+             try:
+                self.qb.download_from_file(filedata, label=self.conf('label'))
+                log.info('Torrent [file] sent to QBittorrent successfully.')
+                return self.downloadReturnId(torrent_hash)
+             except Exception as e:
+                log.error('Failed to send torrent to qBittorrent: %s', e)
+                return False
 
     def getTorrentStatus(self, torrent):
 


### PR DESCRIPTION
### Description of what this fixes:
Existing qBittorrent downloader required magnets to be converted to files, and failed frequently due to torcache availability. Updated downloader to support native magnet downloaders as already supported in the qbittorrent library class.

Never coded in python before - borrowed from working uTorrent downloader for inspiration, feel free to flame me but it works for me locally so thought it best to share.

### Related issues:
unable to download files with qBittorrent downloader due to torcache being unavailable.