### PR TITLE
Adding itorrents.org to the torrent cache sources

### DIFF
--- a/couchpotato/core/_base/downloader/main.py
+++ b/couchpotato/core/_base/downloader/main.py
@@ -26,6 +26,7 @@ class DownloaderBase(Provider):
 
     torrent_sources = [
         'https://torcache.net/torrent/%s.torrent',
+        'http://itorrents.org/torrent/%s.torrent'
     ]
 
     torrent_trackers = [


### PR DESCRIPTION
### Description of what this fixes:
... It provides a working torrent cache source

### Related issues:
... #6645

