### PR TITLE
torrentday fix

### DIFF
--- a/couchpotato/core/media/_base/providers/base.py
+++ b/couchpotato/core/media/_base/providers/base.py
@@ -167,7 +167,7 @@ class YarrProvider(Provider):
                 self.login_failures = 0
                 return True
 
-            error = 'unknowntest'
+            error = 'unknown'
         except Exception as e:
             if isinstance(e, HTTPError):
                 if e.response.status_code >= 400 and e.response.status_code < 500:

--- a/couchpotato/core/media/_base/providers/base.py
+++ b/couchpotato/core/media/_base/providers/base.py
@@ -73,7 +73,7 @@ class Provider(Plugin):
     def getJsonData(self, url, decode_from = None, **kwargs):
 
         cache_key = md5(url)
-        data = self.getCache(cache_key, url, **kwargs)
+        data = self.getCache(cache_key, url, **kwargs)		
 
         if data:
             try:
@@ -167,7 +167,7 @@ class YarrProvider(Provider):
                 self.login_failures = 0
                 return True
 
-            error = 'unknown'
+            error = 'unknowntest'
         except Exception as e:
             if isinstance(e, HTTPError):
                 if e.response.status_code >= 400 and e.response.status_code < 500:
@@ -201,6 +201,9 @@ class YarrProvider(Provider):
 
     def getLoginParams(self):
         return {}
+
+    def getCookies(self):
+	return {}
 
     def download(self, url = '', nzb_id = ''):
         try:

--- a/couchpotato/core/media/_base/providers/torrent/torrentday.py
+++ b/couchpotato/core/media/_base/providers/torrent/torrentday.py
@@ -19,6 +19,14 @@ class Base(TorrentProvider):
 
     http_time_between_calls = 1  # Seconds
 
+    def loginDownload(self, url = '', nzb_id = ''):
+        try:
+            if not self.login():
+                log.error('Failed downloading from %s', self.getName())
+            return self.urlopen(url, headers=self.getRequestHeaders())
+        except:
+            log.error('Failed downloading from %s: %s', (self.getName(), traceback.format_exc()))
+
     def _searchOnTitle(self, title, media, quality, results):
 
         query = '"%s" %s' % (title, media['info']['year'])
@@ -31,7 +39,7 @@ class Base(TorrentProvider):
             'search': query,
         }
 
-        data = self.getJsonData(self.urls['search'], data = data)
+        data = self.getJsonData(self.urls['search'], data = data, headers = self.getRequestHeaders())
         try: torrents = data.get('Fs', [])[0].get('Cn', {}).get('torrents', [])
         except: return
 
@@ -48,6 +56,11 @@ class Base(TorrentProvider):
 
     def getCookies(self):
 	return self.conf('cookiesetting')
+
+    def getRequestHeaders(self):
+        return {
+            'Cookie': self.getCookies()
+        }
 
     def getLoginParams(self):
         return {

--- a/couchpotato/core/media/_base/providers/torrent/torrentday.py
+++ b/couchpotato/core/media/_base/providers/torrent/torrentday.py
@@ -9,12 +9,12 @@ log = CPLog(__name__)
 class Base(TorrentProvider):
 
     urls = {
-        'test': 'https://torrentday.eu/',
-        'login': 'https://torrentday.eu/torrents/',
-        'login_check': 'https://torrentday.eu/userdetails.php',
-        'detail': 'https://torrentday.eu/details.php?id=%s',
-        'search': 'https://torrentday.eu/V3/API/API.php',
-        'download': 'https://torrentday.eu/download.php/%s/%s',
+        'test': 'https://classic.torrentday.com/',
+        'login': 'https://classic.torrentday.com/torrents/',
+        'login_check': 'https://classic.torrentday.com/userdetails.php',
+        'detail': 'https://classic.torrentday.com/details.php?id=%s',
+        'search': 'https://classic.torrentday.com/V3/API/API.php',
+        'download': 'https://classic.torrentday.com/download.php/%s/%s',
     }
 
     http_time_between_calls = 1  # Seconds
@@ -46,6 +46,9 @@ class Base(TorrentProvider):
                 'leechers': tryInt(torrent.get('leech')),
             })
 
+    def getCookies(self):
+	return self.conf('cookiesetting')
+
     def getLoginParams(self):
         return {
             'username': self.conf('username'),
@@ -73,7 +76,7 @@ config = [{
             'tab': 'searcher',
             'list': 'torrent_providers',
             'name': 'TorrentDay',
-            'description': '<a href="https://torrentday.eu/" target="_blank">TorrentDay</a>',
+            'description': '<a href="https://classic.torrentday.com/" target="_blank">TorrentDay</a>',
             'wizard': True,
             'icon': 'iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAC5ElEQVQ4y12TXUgUURTH//fO7Di7foeQJH6gEEEIZZllVohfSG/6UA+RSFAQQj74VA8+Bj30lmAlRVSEvZRfhNhaka5ZUG1paKaW39tq5O6Ou+PM3M4o6m6X+XPPzD3zm/+dcy574r515WfIW8CZBM4YAA5Gc/aQC3yd7oXYEONcsISE5dTDh91HS0t7FEWhBUAeN9ynV/d9qJAgE4AECURAcVsGlCCnly26LMA0IQwTa52dje3d3e3hcPi8qqrrMjcVYI3EHCQZlkFOHBwR2QHh2ASAAIJxWGAQEDxjePhs3527XjJwnb37OHBq0T+Tyyjh+9KnEzNJ7nouc1Q/3A3HGsOvnJy+PSUlj81w2Lny9WuJ6+3AmTjD4HOcrdR2dWXLRQePvyaSLfQOPMPC8mC9iHCsOxSyzJCelzdSXlNzD5ujpb25Wbfc/XXJemTXF4+nnCNq+AMLe50uFfEJTiw4GXSFtiHL0SnIq66+p0kSArqO+eH3RdsAv9+f5vW7L7GICq6rmM8XBCAXlBw90rOyxibn5yzfkg/L09M52/jxqdESaIrBXHYZZbB1GX8cEpySxKIB8S5XcOnvqpli1zuwmrTtoLjw5LOK/eeuWsE4JH5IRPaPZKiKigmPp+5pa+u1aEjIMhEgrRkmi9mgxGUhM7LNJSzOzsE3+cOeExovXOjdytE0LV4zqNZUtV0uZzAGoGkhDH/2YHZiErmv4uyWQnZZWc+hoqL3WzlTExN5hhA8IEwkZWZOxwB++30YG/9GkYCPvqAaHAW5uWPROW86OmqCprUR7z1yZDAGQNuCvkoB/baIKUBWMTYymv+gra3eJNvjXu+B562tFyXqTJ6YuHK8rKwvBmC3vR7cOCPQLWFz8LnfXWUrJo9U19BwMyUlJRjTSMJ2ENxUiGxq9KXQfwqYlnWstvbR5aamG9g0uzM8Q4OFt++3NNixQ2NgYmeN03FOTUv7XVpV9aKisvLl1vN/WVhNc/Fi1NEAAAAASUVORK5CYII=',
             'options': [
@@ -104,6 +107,12 @@ config = [{
                     'type': 'int',
                     'default': 40,
                     'description': 'Will not be (re)moved until this seed time (in hours) is met.',
+                },
+                {
+                    'name': 'cookiesetting',
+                    'label': 'Cookies',
+                    'default': '',
+                    'description': 'Cookies',
                 },
                 {
                     'name': 'extra_score',

--- a/couchpotato/core/plugins/base.py
+++ b/couchpotato/core/plugins/base.py
@@ -124,7 +124,7 @@ class Plugin(object):
         try:
             if not os.path.isdir(path):
                 os.makedirs(path, Env.getPermission('folder'))
-                os.chmod(path, Env.getPermission('folder'))		
+                os.chmod(path, Env.getPermission('folder'))
             return True
         except Exception as e:
             log.error('Unable to create folder "%s": %s', (path, e))

--- a/couchpotato/core/plugins/base.py
+++ b/couchpotato/core/plugins/base.py
@@ -124,7 +124,6 @@ class Plugin(object):
         try:
             if not os.path.isdir(path):
                 os.makedirs(path, Env.getPermission('folder'))
-                os.chmod(path, Env.getPermission('folder'))
             return True
         except Exception as e:
             log.error('Unable to create folder "%s": %s', (path, e))
@@ -171,10 +170,6 @@ class Plugin(object):
         headers['Accept-encoding'] = headers.get('Accept-encoding', 'gzip')
         headers['Connection'] = headers.get('Connection', 'keep-alive')
         headers['Cache-Control'] = headers.get('Cache-Control', 'max-age=0')
-
-        if self.getName() is "TorrentDay":
-		cookies = self.getCookies()
-		headers['Cookie'] = cookies
 
         use_proxy = Env.setting('use_proxy')
         proxy_url = None

--- a/couchpotato/core/plugins/base.py
+++ b/couchpotato/core/plugins/base.py
@@ -155,7 +155,8 @@ class Plugin(object):
 
     # http request
     def urlopen(self, url, timeout = 30, data = None, headers = None, files = None, show_error = True, stream = False):
-        url = quote(ss(url), safe = "%/:=&?~#+!$,;'@()*[]")
+
+	url = quote(ss(url), safe = "%/:=&?~#+!$,;'@()*[]")
 
         if not headers: headers = {}
         if not data: data = {}
@@ -170,6 +171,10 @@ class Plugin(object):
         headers['Accept-encoding'] = headers.get('Accept-encoding', 'gzip')
         headers['Connection'] = headers.get('Connection', 'keep-alive')
         headers['Cache-Control'] = headers.get('Cache-Control', 'max-age=0')
+
+        if self.getName() is "TorrentDay":
+		cookies = self.getCookies()
+		headers['Cookie'] = cookies
 
         use_proxy = Env.setting('use_proxy')
         proxy_url = None

--- a/couchpotato/core/plugins/base.py
+++ b/couchpotato/core/plugins/base.py
@@ -124,6 +124,7 @@ class Plugin(object):
         try:
             if not os.path.isdir(path):
                 os.makedirs(path, Env.getPermission('folder'))
+                os.chmod(path, Env.getPermission('folder'))		
             return True
         except Exception as e:
             log.error('Unable to create folder "%s": %s', (path, e))

--- a/couchpotato/core/plugins/base.py
+++ b/couchpotato/core/plugins/base.py
@@ -155,8 +155,7 @@ class Plugin(object):
 
     # http request
     def urlopen(self, url, timeout = 30, data = None, headers = None, files = None, show_error = True, stream = False):
-
-	url = quote(ss(url), safe = "%/:=&?~#+!$,;'@()*[]")
+        url = quote(ss(url), safe = "%/:=&?~#+!$,;'@()*[]")
 
         if not headers: headers = {}
         if not data: data = {}


### PR DESCRIPTION
### Description of what this fixes:
torrentday captcha problem
in order to solve this, user enters the cookie details into the login details of torrentday selection. if these details exist, for torrentday, the browser also sends the cookie details in request header.

### Related issues:
#5869 #6729 #6530 #6518 #6515 #6514 #6548 #6542 #6562 #6590 and many more


