### PR TITLE
Fix IPTorrents Class to ID Change

### DIFF
--- a/couchpotato/core/media/_base/providers/torrent/iptorrents.py
+++ b/couchpotato/core/media/_base/providers/torrent/iptorrents.py
@@ -61,7 +61,7 @@ class Base(TorrentProvider):
                             final_page_link = next_link.previous_sibling.previous_sibling
                             pages = int(final_page_link.string)
 
-                    result_table = html.find('table', attrs = {'class': 'torrents'})
+                    result_table = html.find('table', attrs = {'id': 'torrents'})
 
                     if not result_table or 'nothing found!' in data.lower():
                         return


### PR DESCRIPTION
### Description of what this fixes:
IPTorrents search was broken because it was searching for a table with class 'torrents' but this was modified to be a table with ID 'torrents'.

### Related issues:
IPTorrents search has been broken for a few days.

