### PR TITLE
Add Movie Title to TorrentPotato Requests

### DIFF
--- a/couchpotato/core/media/movie/providers/torrent/torrentpotato.py
+++ b/couchpotato/core/media/movie/providers/torrent/torrentpotato.py
@@ -1,5 +1,6 @@
 from couchpotato.core.helpers.encoding import tryUrlencode
 from couchpotato.core.helpers.variable import getIdentifier
+from couchpotato.core.helpers.variable import getTitle
 from couchpotato.core.logger import CPLog
 from couchpotato.core.media._base.providers.torrent.torrentpotato import Base
 from couchpotato.core.media.movie.providers.base import MovieProvider
@@ -16,5 +17,6 @@ class TorrentPotato(MovieProvider, Base):
             'user': host['name'],
             'passkey': host['pass_key'],
             'imdbid': getIdentifier(media),
+            'search' : getTitle(media),
         })
         return '%s?%s' % (host['host'], arguments)


### PR DESCRIPTION
As discussed here https://github.com/Jackett/Jackett/issues/462#issuecomment-241972123 only the IMDB ID was being transmitted, no movie title