### PR TITLE
Insert the name of the program being updated in the notifier

### DIFF
--- a/couchpotato/core/_base/updater/main.py
+++ b/couchpotato/core/_base/updater/main.py
@@ -98,7 +98,7 @@ class Updater(Plugin):
                     if self.conf('notification'):
                         info = self.updater.info()
                         version_date = datetime.fromtimestamp(info['update_version']['date'])
-                        fireEvent('updater.updated', 'Updated to a new version with hash "%s", this version is from %s' % (info['update_version']['hash'], version_date), data = info)
+                        fireEvent('updater.updated', 'CouchPotato: Updated to a new version with hash "%s", this version is from %s' % (info['update_version']['hash'], version_date), data = info)
                 except:
                     log.error('Failed notifying for update: %s', traceback.format_exc())
 


### PR DESCRIPTION
This is useful in the case several programs use the same channel
to notify for updates, it is now possible to know which program
was updated within a simple view instead of guessing

### Related issues:
None

### Other information according to guidelines:
PR has not been tested, as the change is trivial. 

It doesn't have any limitations.

PR is up-to-date with the develop branch.