### PR TITLE
Modify force renamer from hours to minutes. This allows finer grained…

### DIFF
--- a/couchpotato/core/plugins/renamer.py
+++ b/couchpotato/core/plugins/renamer.py
@@ -71,7 +71,7 @@ class Renamer(Plugin):
 
         fireEvent('schedule.remove', 'renamer.check_snatched_forced')
         if self.isEnabled() and self.conf('force_every') > 0:
-            fireEvent('schedule.interval', 'renamer.check_snatched_forced', self.scan, hours = self.conf('force_every'), single = True)
+            fireEvent('schedule.interval', 'renamer.check_snatched_forced', self.scan, minutes = self.conf('force_every'), single = True)
 
         return True
 
@@ -1410,10 +1410,10 @@ config = [{
                     'advanced': True,
                     'name': 'force_every',
                     'label': 'Force every',
-                    'default': 2,
+                    'default': 720,
                     'type': 'int',
-                    'unit': 'hour(s)',
-                    'description': 'Forces the renamer to scan every X hours',
+                    'unit': 'min(s)',
+                    'description': 'Forces the renamer to scan every X minutes',
                 },
                 {
                     'advanced': True,


### PR DESCRIPTION
### Description of what this fixes:
Currently if user wants to force renamer to run more frequent then n Hours (1,2 etc) this is not possible. Fractional hours are not allowed as variable is recorded as int. By modifying unit from hours to minutes users who wish to do so can happily specify to the minute the frequency of forced renamer.

I use CouchPotato to rename and move movies that I have personally selected and downloaded (the completed download is moved to the watch folder). Waiting upto 1 hour for couch potato to recognise that a new movie has appeared is sub-optimal.

### Related issues:
Updating existing installs. I am not sure how the conversion from hour to minutes would be managed for users simply upgrading inplace. I do imagine that this is an edge case, most users would either use CP to managed the full download stack (in which case this value likely remains default) or are like myself and would probably prefer a more frequent option for force renamer.  
