### PR TITLE
Added thepiratebay.org to piratebay proxy list

### DIFF
--- a/couchpotato/core/media/_base/providers/torrent/thepiratebay.py
+++ b/couchpotato/core/media/_base/providers/torrent/thepiratebay.py
@@ -54,6 +54,7 @@ class Base(TorrentMagnetProvider):
         'https://arrr.xyz',
         'https://www.cleantpbproxy.com',
         'http://tpb.dashitz.com',
+        'https://thepiratebay.org',
     ]
 
     def __init__(self):


### PR DESCRIPTION
### Description of what this fixes:
Adds thepiratebay.org to the default proxy list available for piratebay.

### Related issues:
...

