### PR TITLE
SABnzbd connection test would fail when user is on SABnzbd-develop

### DIFF
--- a/couchpotato/core/downloaders/sabnzbd.py
+++ b/couchpotato/core/downloaders/sabnzbd.py
@@ -95,7 +95,7 @@ class Sabnzbd(DownloaderBase):
                 'mode': 'version',
             })
             v = sab_data.split('.')
-            if int(v[0]) == 0 and int(v[1]) < 7:
+            if sab_data != 'develop' and int(v[0]) == 0 and int(v[1]) < 7:
                 return False, 'Your Sabnzbd client is too old, please update to newest version.'
 
             # the version check will work even with wrong api key, so we need the next check as well


### PR DESCRIPTION
### Description of what this fixes:
When a user was on the SABnzbd develop branch (like many users on QNAP devices, since it uses ```git``` to keep SABnzbd up-to-date), CP would say 'Connection failed' because the ```int(v[0])``` throws an:
```
ValueError: invalid literal for int() with base 10: 'develop'
```
However, sending NZB's worked just fine. It just confused users.


### Related issues:
None

