### PR TITLE
Prevent hanging on large gitconfig files

### DIFF
--- a/libs/git/repository.py
+++ b/libs/git/repository.py
@@ -23,6 +23,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 from collections import Sequence
+from cStringIO import StringIO
 import re
 import os
 import subprocess
@@ -76,7 +77,9 @@ class Repository(ref_container.RefContainer):
                                     cwd = cwd,
                                     stdout = subprocess.PIPE,
                                     stderr = subprocess.PIPE)
-        returned.wait()
+        stdout, stderr = returned.communicate()
+        returned.stdout = StringIO(stdout)
+        returned.stderr = StringIO(stderr)
         return returned
     def _executeGitCommandAssertSuccess(self, command, **kwargs):
         returned = self._executeGitCommand(command, **kwargs)


### PR DESCRIPTION
### Description of what this fixes:

CouchPotato can hang on startup if the gitconfig file is too large, this diff fixes that.

`Popen.wait` can block if the output it too big, this change switches to communicate to fix the block.

see the note on `wait` on the python docs: https://docs.python.org/2/library/subprocess.html#subprocess.Popen.wait
