### PR TITLE
Correctly parse git config output

### DIFF
--- a/libs/git/config.py
+++ b/libs/git/config.py
@@ -39,5 +39,8 @@ class GitConfiguration(object):
     def getParameter(self, path):
         return self.getDict().get(path, None)
     def getDict(self):
-        return dict(line.strip().split("=", 1)
-                    for line in self.repo._getOutputAssertSuccess("config -l").splitlines())
+        return dict(
+            line.strip().split('\n', 1)
+            for line in self.repo._getOutputAssertSuccess("config --null --list").split('\x00')
+            if line
+        )


### PR DESCRIPTION
### Description of what this fixes:

The git library does not correctly parse config output

`git config --list` outputs the config and interprets characters like newlines. This means that `splitlines` does not correctly split the file by command.

`git config` also allows a `--null` option to specify a null terminator, using this we can correctly split the output of `git config --list`
