### PR TITLE
Small change to 2 values

### DIFF
--- a/couchpotato/core/media/movie/providers/info/omdbapi.py
+++ b/couchpotato/core/media/movie/providers/info/omdbapi.py
@@ -40,7 +40,7 @@ class OMDBAPI(MovieProvider):
 
         cache_key = 'omdbapi.cache.%s' % q
         url = self.urls['search'] % tryUrlencode({'t': name_year.get('name'), 'y': name_year.get('year', '')})
-        cached = self.getCache(cache_key, url, timeout = 3, headers = {'User-Agent': Env.getIdentifier()})
+        cached = self.getCache(cache_key, url, timeout = 7, headers = {'User-Agent': Env.getIdentifier()})
 
         if cached:
             result = self.parseMovie(cached)

--- a/couchpotato/core/plugins/scanner.py
+++ b/couchpotato/core/plugins/scanner.py
@@ -63,7 +63,7 @@ class Scanner(Plugin):
     }
 
     file_sizes = {  # in MB
-        'movie': {'min': 200},
+        'movie': {'min': 300},
         'trailer': {'min': 2, 'max': 199},
         'backdrop': {'min': 0, 'max': 5},
     }


### PR DESCRIPTION
### Description of what this fixes:

**OMDB Timeout to 7 seconds:**
OMDBAPI is regularly timing out:
`10-30 17:50:51 ERROR [hpotato.core.plugins.base] Failed opening url in OMDBAPI: http://www.omdbapi.com/?type=movie&y=&t=filofax Traceback (most recent call last):
ReadTimeout: HTTPConnectionPool(host='www.omdbapi.com', port=80): Read timed out. (read timeout=3)`
_Suggestion:_ raise from 3 to 7 seconds

"Detect as movie limit" of 200MB seems too small for scanner/renamer tasks as CP regularly tries to parse/tag episodes of TV shows that it incorrectly queues as movies just to error out a couple seconds later with "movie not found" exceptions.
`10-30 16:29:37 ERROR [tato.core.plugins.scanner] No imdb_id found for [u'video file bigger than 200mb', u'video file bigger than 200mb']. Add a NFO file with IMDB id or add the year to the filename.`
_Suggestion:_ raise from 200MB to 300MB
