### PR TITLE
Changing the CHMOD to 0750

### DIFF
--- a/init/ubuntu
+++ b/init/ubuntu
@@ -61,7 +61,7 @@ start_cp() {
 	# (but refuse to touch any pre-existing ones)
 	for D in "$(dirname "$CP_PIDFILE")" "$CP_DATA"; do
 		[ ! -d "$D" ] && {
-			install --directory --owner="$CP_USER" --group=root --mode=0700 "$D" || exit 1;
+			install --directory --owner="$CP_USER" --group=root --mode=0750 "$D" || exit 1;
 		}
 	done
 


### PR DESCRIPTION
This allows monitoring software, like monit, to be able to use the .pid file to track if its running. Plus, I don't think I've ever seen permissions that restrictive?