### PR TITLE
issue with none ascii chars in title name. decode to utf-8 and encode…

### DIFF
--- a/couchpotato/core/media/movie/providers/automation/base.py
+++ b/couchpotato/core/media/movie/providers/automation/base.py
@@ -45,7 +45,8 @@ class Automation(AutomationBase):
 
     def search(self, name, year = None, imdb_only = False):
 
-        prop_name = 'automation.cached.%s.%s' % (name, year)
+        cache_name = name.decode('utf-8').encode('ascii', 'ignore')
+        prop_name = 'automation.cached.%s.%s' % (cache_name, year)
         cached_imdb = Env.prop(prop_name, default = False)
         if cached_imdb and imdb_only:
             return cached_imdb


### PR DESCRIPTION
### Description of what this fixes:
... I had issues with automation when I turned on blu-ray.com integration today, unfortunately nothing was added to the watch list. After a little debugging it turned out a few days ago "Mötley Crüe: The End - Live in Los Angeles" was released and it was killing the cache check.

this fix just removes the none assci chars from the cache key. 

### Related issues:
...

… to ascii strips (for some reason the simple encode didn't work?