### PR TITLE
Display eta's

### DIFF
--- a/couchpotato/core/media/movie/_base/static/details.js
+++ b/couchpotato/core/media/movie/_base/static/details.js
@@ -36,14 +36,18 @@ var MovieDetails = new Class({
 			)
 		);
 
-		var eta_date = parent.getETA('%b %Y') ;
+		var eta_date = parent.getETA('%b %d, %Y') ;
+		var dvd_date = parent.getDVDRelease('%b %d, %Y') ;
+		var theater_date = parent.getTheaterRelease('%b %d, %Y') ;
 		self.addSection('description', new Element('div').adopt(
 			new Element('div', {
 				'text': parent.get('plot')
 			}),
 			new Element('div.meta', {
 				'html':
-					(eta_date ? ('<span>ETA:' + eta_date + '</span>') : '') +
+					(theater_date ? ('<span>Theatrical Release: ' + theater_date + '<span>') : '') +
+					(dvd_date ? ('<span>DVD Release: ' + dvd_date + '<span>') : '') +
+					//(eta_date ? ('<span>ETA: ' + eta_date + '</span>') : '') +
 					'<span>' + (parent.get('genres') || []).join(', ') + '</span>'
 			})
 		));

--- a/couchpotato/core/media/movie/_base/static/movie.js
+++ b/couchpotato/core/media/movie/_base/static/movie.js
@@ -190,7 +190,20 @@ var Movie = new Class({
 
 		self.el.addClass('status_'+self.get('status'));
 
-		var eta_date = self.getETA();
+		var eta_date = self.getETA("%b %d, %Y");
+		var dvd_date = self.getDVDRelease("%b %d, %Y");
+		var theater_date = self.getTheaterRelease("%b %d, %Y");
+		var eta_type = "ETA: "
+		if (eta_date)
+                        eta_type = eta_date == dvd_date ? "DVD ETA: " : "Theatrical ETA ";
+                else if (dvd_date){
+			eta_type = "DVD released: ";
+			eta_date = dvd_date;
+		}
+		else if (theater_date){
+			eta_type = "Theatrically released: ";
+			eta_date = theater_date;
+		}
 
 		var rating, stars;
 		if(['suggested','chart'].indexOf(self.data.status) > -1 && self.data.info && self.data.info.rating && self.data.info.rating.imdb){
@@ -245,8 +258,16 @@ var Movie = new Class({
 						'text': self.data.info.year || 'n/a'
 					})
 				),
+				//theater_date ? new Element('div.theaterdate', {
+				//	'text': "Theatrical Release: " +theater_date,
+				//	'title': 'TheaterDate'
+				//}) : null,
+				//dvd_date ? new Element('div.dvddate', {
+				//	'text': "DVD Release: "+dvd_date,
+				//	'title': 'DVDDate'
+				//}) : null,
 				eta_date ? new Element('div.eta', {
-					'text': eta_date,
+					'text': eta_type+eta_date,
 					'title': 'ETA'
 				}) : null,
 				self.quality = new Element('div.quality'),
@@ -411,6 +432,38 @@ var Movie = new Class({
 		return self.get('imdb');
 	},
 
+	getDVDRelease: function(format){
+		var self = this,
+		d=null,
+		d_date = '';
+		if (self.data.info.release_date)
+			[self.data.info.release_date.dvd].each(function(timestamp){
+				if (timestamp > 0)
+			               d = timestamp;
+			});
+		if (d){
+                        d_date = new Date (d*1000);
+		        d_date = d_date.format(format);
+		}
+		return d_date;
+	},
+
+	getTheaterRelease: function(format){
+		var self = this,
+		d=null,
+		d_date = '';
+		if (self.data.info.release_date)
+			[self.data.info.release_date.theater].each(function(timestamp){
+				if (timestamp > 0)
+			               d = timestamp;
+		});
+		if (d){
+                        d_date = new Date (d*1000);
+		        d_date = d_date.format(format);
+		}
+		return d_date;
+	},
+
 	getETA: function(format){
 		var self = this,
 			d = new Date(),
@@ -430,11 +483,12 @@ var Movie = new Class({
 				eta_date = null;
 			}
 			else {
-				eta_date = format ? eta_date.format(format) : (eta_date.format('%b') + (d.getFullYear() != eta_date.getFullYear() ? ' ' + eta_date.getFullYear() : ''));
+			        eta_date = format ? eta_date.format(format) : (eta_date.format('%b %d'));
 			}
 		}
-
-		return (now+8035200 > eta) ? eta_date : '';
+                return eta_date;
+		//removing below line since this only returns if movie's ETA is within the next 93 days - we want to always return, then decide when to display it
+		//return (now+8035200 > eta) ? eta_date : '';
 	},
 
 	get: function(attr){

--- a/couchpotato/core/media/movie/_base/static/movie.scss
+++ b/couchpotato/core/media/movie/_base/static/movie.scss
@@ -315,7 +315,6 @@ $mass_edit_height: 44px;
 					display: none;
 				}
 			}
-
 			.quality {
 				clear: both;
 				overflow: hidden;
@@ -468,16 +467,19 @@ $mass_edit_height: 44px;
 		}
 
 		.info {
+			display :flex;
+			flex-direction : column;
 			clear: both;
 			font-size: .9em;
 
 			.title {
+				order : 1;
 				display: flex;
 				padding: 3px 0;
 				font-weight: 400;
 
 				span {
-					flex: 1 auto;
+					//flex: 1 auto;
 					white-space: nowrap;
 					overflow: hidden;
 					text-overflow: ellipsis;
@@ -491,12 +493,19 @@ $mass_edit_height: 44px;
 			}
 
 			.eta {
+				order : 3;
+				font-size: .9em;
 				opacity: .5;
 				float: right;
 				margin-left: 4px;
+				span {
+					flex: 1 auto;
+					white-space: nowrap;
+					overflow: hidden;
+				}
 			}
-
 			.quality {
+				order: 2;
 				white-space: nowrap;
 				overflow: hidden;
 				font-size: .9em;

--- a/couchpotato/static/scripts/combined.plugins.min.js
+++ b/couchpotato/static/scripts/combined.plugins.min.js
@@ -340,11 +340,13 @@ var MovieDetails = new Class({
             button_text: parent.getTitle() + (parent.get("year") ? " (" + parent.get("year") + ")" : ""),
             button_class: "icon-dropdown"
         })), self.buttons = new Element("div.buttons"))));
-        var eta_date = parent.getETA("%b %Y");
+        var eta_date = parent.getETA("%b %d, %Y");
+        var dvd_date = parent.getDVDRelease("%b %d, %Y");
+        var theater_date = parent.getTheaterRelease("%b %d, %Y");
         self.addSection("description", new Element("div").adopt(new Element("div", {
             text: parent.get("plot")
         }), new Element("div.meta", {
-            html: (eta_date ? "<span>ETA:" + eta_date + "</span>" : "") + "<span>" + (parent.get("genres") || []).join(", ") + "</span>"
+            html: (theater_date ? "<span>Theatrical Release: " + theater_date + "<span>" : "") + (dvd_date ? "<span>DVD Release: " + dvd_date + "<span>" : "") + "<span>" + (parent.get("genres") || []).join(", ") + "</span>"
         })));
         var titles = parent.get("info").titles;
         $(self.title_dropdown).addEvents({
@@ -431,6 +433,11 @@ var MovieList = new Class({
                 display: "none"
             }
         }) : null, self.description = self.options.description ? new Element("div.description", {
+            html: self.options.description,
+            styles: {
+                display: "none"
+            }
+        }) : null, self.description2 = self.options.description ? new Element("div.description", {
             html: self.options.description,
             styles: {
                 display: "none"
@@ -1860,7 +1867,17 @@ var Movie = new Class({
     create: function() {
         var self = this;
         self.el.addClass("status_" + self.get("status"));
-        var eta_date = self.getETA();
+        var eta_date = self.getETA("%b %d, %Y");
+        var dvd_date = self.getDVDRelease("%b %d, %Y");
+        var theater_date = self.getTheaterRelease("%b %d, %Y");
+        var eta_type = "ETA: ";
+        if (eta_date) eta_type = eta_date == dvd_date ? "DVD ETA: " : "Theatrical ETA "; else if (dvd_date) {
+            eta_type = "DVD released: ";
+            eta_date = dvd_date;
+        } else if (theater_date) {
+            eta_type = "Theatrically released: ";
+            eta_date = theater_date;
+        }
         var rating, stars;
         if ([ "suggested", "chart" ].indexOf(self.data.status) > -1 && self.data.info && self.data.info.rating && self.data.info.rating.imdb) {
             rating = Array.prototype.slice.call(self.data.info.rating.imdb);
@@ -1892,7 +1909,7 @@ var Movie = new Class({
         }), new Element("div.year", {
             text: self.data.info.year || "n/a"
         })), eta_date ? new Element("div.eta", {
-            text: eta_date,
+            text: eta_type + eta_date,
             title: "ETA"
         }) : null, self.quality = new Element("div.quality"), rating ? new Element("div.rating[title=" + rating[0] + "]").adopt(stars, new Element("span.votes[text=(" + rating.join(" / ") + ")][title=Votes]")) : null));
         if (!thumbnail) self.el.addClass("no_thumbnail");
@@ -1998,6 +2015,28 @@ var Movie = new Class({
         } catch (e) {}
         return self.get("imdb");
     },
+    getDVDRelease: function(format) {
+        var self = this, d = null, d_date = "";
+        if (self.data.info.release_date) [ self.data.info.release_date.dvd ].each(function(timestamp) {
+            if (timestamp > 0) d = timestamp;
+        });
+        if (d) {
+            d_date = new Date(d * 1e3);
+            d_date = d_date.format(format);
+        }
+        return d_date;
+    },
+    getTheaterRelease: function(format) {
+        var self = this, d = null, d_date = "";
+        if (self.data.info.release_date) [ self.data.info.release_date.theater ].each(function(timestamp) {
+            if (timestamp > 0) d = timestamp;
+        });
+        if (d) {
+            d_date = new Date(d * 1e3);
+            d_date = d_date.format(format);
+        }
+        return d_date;
+    },
     getETA: function(format) {
         var self = this, d = new Date(), now = Math.round(+d / 1e3), eta = null, eta_date = "";
         if (self.data.info.release_date) [ self.data.info.release_date.dvd, self.data.info.release_date.theater ].each(function(timestamp) {
@@ -2008,10 +2047,10 @@ var Movie = new Class({
             if (+eta_date / 1e3 < now) {
                 eta_date = null;
             } else {
-                eta_date = format ? eta_date.format(format) : eta_date.format("%b") + (d.getFullYear() != eta_date.getFullYear() ? " " + eta_date.getFullYear() : "");
+                eta_date = format ? eta_date.format(format) : eta_date.format("%b %d");
             }
         }
-        return now + 8035200 > eta ? eta_date : "";
+        return eta_date;
     },
     get: function(attr) {
         return this.data[attr] || this.data.info[attr];

--- a/couchpotato/static/scripts/combined.vendor.min.js
+++ b/couchpotato/static/scripts/combined.vendor.min.js
@@ -4201,7 +4201,7 @@ if (typeof JSON == "undefined") this.JSON = {};
 (function() {
     var special = {
         "\b": "\\b",
-        "	": "\\t",
+        "\t": "\\t",
         "\n": "\\n",
         "\f": "\\f",
         "\r": "\\r",

--- a/couchpotato/static/scripts/page/home.js
+++ b/couchpotato/static/scripts/page/home.js
@@ -56,7 +56,7 @@ Page.Home = new Class({
 			'view': 'list',
 			'actions': [MA.MarkAsDone, MA.IMDB, MA.Release, MA.Trailer, MA.Refresh, MA.Readd, MA.Delete, MA.Category, MA.Profile],
 			'title': 'Snatched & Available',
-			'description': 'These movies have been snatched or have finished downloading',
+			'description': 'Releases available to snatch, have been snatched and/or finished downloading',
 			'on_empty_element': new Element('div').adopt(
 				new Element('h2', {'text': 'Snatched & Available'}),
 				new Element('span.no_movies', {
@@ -105,7 +105,7 @@ Page.Home = new Class({
 			'identifier': 'soon',
 			'limit': 12,
 			'title': 'Available soon',
-			'description': 'Should be available soon as they will be released on DVD/Blu-ray in the coming weeks.',
+			'description': 'DVD/Blu-ray release date: past 3 months or next 4 weeks',
 			'filter': {
 				'random': true
 			},
@@ -168,8 +168,8 @@ Page.Home = new Class({
 			'navigation': false,
 			'identifier': 'late',
 			'limit': 50,
-			'title': 'Still not available',
-			'description': 'Try another quality profile or maybe add more providers in <a href="' + App.createUrl('settings/searcher/providers/') + '">Settings</a>.',
+			'title': 'Missed',
+			'description': 'DVD release > 3 months ago, Theatrical release > 12 weeks ago. Try another quality profile? <a href="' + App.createUrl('settings/searcher/providers/') + '">Settings</a>.',
 			'filter': {
 				'late': true
 			},


### PR DESCRIPTION
### Description of what this fixes:
This fix displayed more clear ETA information for the movies in the wanted list.

It also updates the titles on the homepage with a better description of what they list.

Also, bypasses couchpotato api for eta information since it is returning nothing or the wrong result. It uses omdbapi instead. Also is commented code for using tmdb but requires tmdb api key to be specified in the code.

### Related issues:
...
