### PR TITLE
Add year to search param for torrentpotato

### DIFF
--- a/couchpotato/core/media/movie/providers/torrent/torrentpotato.py
+++ b/couchpotato/core/media/movie/providers/torrent/torrentpotato.py
@@ -17,6 +17,6 @@ class TorrentPotato(MovieProvider, Base):
             'user': host['name'],
             'passkey': host['pass_key'],
             'imdbid': getIdentifier(media),
-            'search' : getTitle(media),
+            'search' : getTitle(media) + ' ' + str(media['info']['year']),
         })
         return '%s?%s' % (host['host'], arguments)


### PR DESCRIPTION
### Description of what this fixes:
Jackett returns only 50 results for each search, without searching on year it is impossible to get a good hit.

I'm not used to python and this was a quick fix, so i'm not sure if this is how you do it in python.