### PR TITLE
Fix BeautifulSoup find_all parsing

### DIFF
--- a/couchpotato/core/media/_base/providers/torrent/bithdtv.py
+++ b/couchpotato/core/media/_base/providers/torrent/bithdtv.py
@@ -39,7 +39,7 @@ class Base(TorrentProvider):
             if '## SELECT COUNT(' in split_data[0]:
                 data = split_data[2]
 
-            html = BeautifulSoup(data)
+            html = BeautifulSoup(data, 'html.parser')
 
             try:
                 result_table = html.find('table', attrs = {'width': '750', 'class': ''})


### PR DESCRIPTION
### Description of what this fixes:
BeautifulSoup only returns a single TR tag regardless of the amount of results at line 49. Since the first TR tag returned isn't an actual result, you never get any results back. Explicitly calling the html parser fixes this issue.

http://stackoverflow.com/questions/16322862/beautiful-soup-findall-doent-find-them-all

### Related issues:
...