### PR TITLE
add Accept: * header to urlopen

### DIFF
--- a/couchpotato/core/plugins/base.py
+++ b/couchpotato/core/plugins/base.py
@@ -168,6 +168,7 @@ class Plugin(object):
         headers['Host'] = headers.get('Host', None)
         headers['User-Agent'] = headers.get('User-Agent', self.user_agent)
         headers['Accept-encoding'] = headers.get('Accept-encoding', 'gzip')
+        headers['Accept'] = headers.get('Accept', '*')
         headers['Connection'] = headers.get('Connection', 'keep-alive')
         headers['Cache-Control'] = headers.get('Cache-Control', 'max-age=0')
 


### PR DESCRIPTION
Needed for magnetdl, it returns nothing if none Accept header is present, so magnetdl provider is not working, you can test with wget:

```
wget -O - http://www.magnetdl.com/t/tempting-fate-1998/se/desc/1/
wget --header="Accept: *" -O - http://www.magnetdl.com/t/tempting-fate-1998/se/desc/1/
```

Accept: * shouldn't break other providers.
