### PR TITLE
Remove kat.cr and fix trailing slash

### DIFF
--- a/couchpotato/core/media/_base/providers/torrent/kickasstorrents.py
+++ b/couchpotato/core/media/_base/providers/torrent/kickasstorrents.py
@@ -45,8 +45,7 @@ class Base(TorrentMagnetProvider):
         'https://kickass.bypassed.live',
         'https://kickass.bypassed.video',
         'https://kickass.bypassed.red',
-        'https://kat.cr',
-        'https://kickass.unblocked.pw/',
+        'https://kickass.unblocked.pw',
         'https://katproxy.com'
     ]
 


### PR DESCRIPTION
### Description of what this fixes:

kat.cr is a dead domain, and the trailing slash on the proxy array item is erroneous.
