### PR TITLE
Update nzbclub.py (fix bug)

### DIFF
--- a/couchpotato/core/media/movie/providers/nzb/nzbclub.py
+++ b/couchpotato/core/media/movie/providers/nzb/nzbclub.py
@@ -14,7 +14,7 @@ class NZBClub(MovieProvider, Base):
     def buildUrl(self, media):
 
         q = tryUrlencode({
-            'q': '"%s"' % fireEvent('library.query', media, single = True),
+            'q': '%s' % fireEvent('library.query', media, single = True),
         })
 
         query = tryUrlencode({


### PR DESCRIPTION
### Description of what this fixes:
Fix currently broken searches via NZBClub.  Search produces 0 results due to syntax error

### Related issues:
none
