### PR TITLE
Add 2160p support to PTP provider

### DIFF
--- a/couchpotato/core/media/movie/providers/torrent/passthepopcorn.py
+++ b/couchpotato/core/media/movie/providers/torrent/passthepopcorn.py
@@ -10,6 +10,7 @@ autoload = 'PassThePopcorn'
 class PassThePopcorn(MovieProvider, Base):
 
     quality_search_params = {
+        '2160p': {'resolution': '4K'},
         'bd50': {'media': 'Blu-ray', 'format': 'BD50'},
         '1080p': {'resolution': '1080p'},
         '720p': {'resolution': '720p'},
@@ -24,6 +25,7 @@ class PassThePopcorn(MovieProvider, Base):
     }
 
     post_search_filters = {
+        '2160p': {'Resolution': ['4K']},
         'bd50': {'Codec': ['BD50']},
         '1080p': {'Resolution': ['1080p']},
         '720p': {'Resolution': ['720p']},


### PR DESCRIPTION
### Description of what this fixes:
Fixes error in PTP provider when searching 2160p and allows search to complete successfully