### PR TITLE
Add option to configure search categories for Newznab providers

### DIFF
--- a/couchpotato/core/media/_base/providers/nzb/newznab.py
+++ b/couchpotato/core/media/_base/providers/nzb/newznab.py
@@ -128,6 +128,7 @@ class Base(NZBProvider, RSS):
         api_keys = splitString(self.conf('api_key'), clean = False)
         extra_score = splitString(self.conf('extra_score'), clean = False)
         custom_tags = splitString(self.conf('custom_tag'), clean = False)
+        custom_categories = splitString(self.conf('custom_categories'), clean = False)
 
         list = []
         for nr in range(len(hosts)):
@@ -144,12 +145,16 @@ class Base(NZBProvider, RSS):
             try: custom_tag = custom_tags[nr]
             except: custom_tag = ''
 
+            try: custom_category = custom_categories[nr].replace(" ", ",")
+            except: custom_category = ''
+
             list.append({
                 'use': uses[nr],
                 'host': host,
                 'api_key': key,
                 'extra_score': score,
-                'custom_tag': custom_tag
+                'custom_tag': custom_tag,
+                'custom_category' : custom_category
             })
 
         return list
@@ -264,6 +269,13 @@ config = [{
                     'label': 'Custom tag',
                     'default': ',,,,,',
                     'description': 'Add custom tags, for example add rls=1 to get only scene releases from nzbs.org',
+                },
+                {
+                    'name': 'custom_categories',
+                    'advanced': True,
+                    'label': 'Custom Categories',
+                    'default': '2000,2000,2000,2000,2000,2000',
+                    'description': 'Specify categories to search in seperated by a single space, defaults to all movies. EG: "2030 2040 2060" would only search in HD, SD, and 3D movie categories',
                 },
                 {
                     'name': 'api_key',

--- a/couchpotato/core/media/movie/providers/nzb/newznab.py
+++ b/couchpotato/core/media/movie/providers/nzb/newznab.py
@@ -23,4 +23,7 @@ class Newznab(MovieProvider, Base):
         if len(host.get('custom_tag', '')) > 0:
             query = '%s&%s' % (query, host.get('custom_tag'))
 
+        if len(host['custom_category']) > 0:
+            query = '%s&cat=%s' % (query, host['custom_category'])
+
         return query


### PR DESCRIPTION
### Description of what this fixes:

The Newznab API function that CouchPotato uses for searching for movies doesn't always search every category on some sites.  As a result some possible results will not be returned.  I personally ran into this using dognzb where I discovered that category 2060 Movies/3D was not included in the search.

This PR adds the ability for the user to configure custom categories lists to use in searches on Newznab providers.  

Beyond fixing this issue, it allows users to better target searches by eliminating categories they might never want to search in such as Movies/Foreign or Movies/SD for example.

This PR will add a new option to the NewzNab settings in Settings->Searcher called "Custom Category" that takes a **space** deliminated list of categories numbers to use in searches.  If set, the query URL will be appended with "cat=" and the list of categories in proper Newznab format.

### Related issues:

https://couchpota.to/forum/viewtopic.php?f=5&t=51270


Geesh everything I typed out vanished.. arg.  Give me a few and I will re-enter it.