### PR TITLE
fixes UnicodeEncodeError for automation scripts

### DIFF
--- a/couchpotato/core/media/movie/providers/automation/base.py
+++ b/couchpotato/core/media/movie/providers/automation/base.py
@@ -1,4 +1,5 @@
 import time
+import unicodedata
 
 from couchpotato.core.event import addEvent, fireEvent
 from couchpotato.core.logger import CPLog
@@ -45,7 +46,11 @@ class Automation(AutomationBase):
 
     def search(self, name, year = None, imdb_only = False):
 
-        cache_name = name.decode('utf-8').encode('ascii', 'ignore')
+        try:
+            cache_name = name.decode('utf-8').encode('ascii', 'ignore')
+        except UnicodeEncodeError:
+            cache_name = unicodedata.normalize('NFKD', name).encode('ascii','ignore')
+
         prop_name = 'automation.cached.%s.%s' % (cache_name, year)
         cached_imdb = Env.prop(prop_name, default = False)
         if cached_imdb and imdb_only:


### PR DESCRIPTION
### Description of what this fixes:
For certain automation options (such as iTunes rss feed), the search method is passed unicode `name` instead of a str and raises UnicodeEncodeError.  This allows for both unicode and str to be passed to the search method.

### Related issues:
...
