### PR TITLE
3d options

### DIFF
--- a/couchpotato/core/plugins/renamer.py
+++ b/couchpotato/core/plugins/renamer.py
@@ -353,9 +353,14 @@ class Renamer(Plugin):
                 if replacements['mpaa_only'] not in ('G', 'PG', 'PG-13', 'R', 'NC-17'):
                     replacements['mpaa_only'] = 'Not Rated'
 
-                replacements['3d_type_short'] = replacements['3d_type_short'].replace('Half ', 'H').replace('Full ', '')
-                if self.conf('use_tab_threed') and 'OU' in replacements['3d_type']:
-                    replacements['3d_type'] = replacements['3d_type'].replace('OU','TAB')
+                if replacements['3d_type_short']:
+                    replacements['3d_type_short'] = replacements['3d_type_short'].replace('Half ', 'H').replace('Full ', '')
+                if self.conf('use_tab_threed') and replacements['3d_type']:
+                    if 'OU' in replacements['3d_type']:
+                        replacements['3d_type'] = replacements['3d_type'].replace('OU','TAB')
+                if self.conf('use_tab_threed') and replacements['3d_type_short']:
+                    if 'OU' in replacements['3d_type_short']:
+                        replacements['3d_type_short'] = replacements['3d_type_short'].replace('OU','TAB')
                     
 
                 for file_type in group['files']:

--- a/couchpotato/core/plugins/renamer.py
+++ b/couchpotato/core/plugins/renamer.py
@@ -347,10 +347,16 @@ class Renamer(Plugin):
                     'category': category_label,
                     '3d': '3D' if group['meta_data']['quality'].get('is_3d', 0) else '',
                     '3d_type': group['meta_data'].get('3d_type'),
+                    '3d_type_short': group['meta_data'].get('3d_type'),
                 }
 
                 if replacements['mpaa_only'] not in ('G', 'PG', 'PG-13', 'R', 'NC-17'):
                     replacements['mpaa_only'] = 'Not Rated'
+
+                replacements['3d_type_short'] = replacements['3d_type_short'].replace('Half ', 'H').replace('Full ', '')
+                if self.conf('use_tab_threed') and 'OU' in replacements['3d_type']:
+                    replacements['3d_type'] = replacements['3d_type'].replace('OU','TAB')
+                    
 
                 for file_type in group['files']:
 
@@ -1298,6 +1304,7 @@ rename_options = {
         'quality_type': '(HD) or (SD)',
         '3d': '3D',
         '3d_type': '3D Type (Full SBS)',
+        '3d_type_short' : 'Short 3D Type (FSBS)',
         'video': 'Video (x264)',
         'audio': 'Audio (DTS)',
         'group': 'Releasegroup name',
@@ -1357,6 +1364,14 @@ config = [{
                     'default': '<thename><cd>.<ext>',
                     'type': 'choice',
                     'options': rename_options
+                },
+                {
+                    'advanced': True,
+                    'name': 'use_tab_threed',
+                    'type': 'bool',
+                    'label': 'Use TAB 3D',
+                    'description': ('Use TAB (Top And Bottom) instead of OU (Over Under).','This will allow Kodi to recognize vertical formatted 3D movies properly.'),
+                    'default': True
                 },
                 {
                     'advanced': True,

--- a/couchpotato/core/plugins/scanner.py
+++ b/couchpotato/core/plugins/scanner.py
@@ -42,9 +42,9 @@ class Scanner(Plugin):
         'Half SBS': [('half', 'sbs'), ('h', 'sbs'), 'hsbs'],
         'Full SBS': [('full', 'sbs'), ('f', 'sbs'), 'fsbs'],
         'SBS': ['sbs'],
-        'Half OU': [('half', 'ou'), ('h', 'ou'), 'hou'],
-        'Full OU': [('full', 'ou'), ('h', 'ou'), 'fou'],
-        'OU': ['ou'],
+        'Half OU': [('half', 'ou'), ('h', 'ou'), ('half', 'tab'), ('h', 'tab'), 'htab', 'hou'],
+        'Full OU': [('full', 'ou'), ('f', 'ou'), ('full', 'tab'), ('f', 'tab'), 'ftab', 'fou'],
+        'OU': ['ou', 'tab'],
         'Frame Packed': ['mvc', ('complete', 'bluray')],
         '3D': ['3d']
     }


### PR DESCRIPTION
### Description of what this fixes:
The current Renamer plugin produces filenames for 3D movies that are not fully compatible with Koid.  This PR adds new settings to the Renamer plugin for Kodi compatability.

Kodi requires the use of TAB instead of OU and only supports compact naming (HSBS instead of Half SBS)

This PR adds two things:
1. It adds a new metadata tag named '3d_type_short' which is the same as '3d_type' but in a short Kodi compatible format, IE 'HSBS' instead of 'Half SBS'
2. It adds an option to use TAB instead of OU
