### PR TITLE
Update deluge.py to allow the user the option of not seeding

### DIFF
--- a/couchpotato/core/downloaders/deluge.py
+++ b/couchpotato/core/downloaders/deluge.py
@@ -159,7 +159,7 @@ class Deluge(DownloaderBase):
             # If an user opts to seed a torrent forever (usually associated to private trackers usage), stop_ratio will be 0 or -1 (depending on Deluge version).
             # In this scenario the status of the torrent would never change from BUSY to SEEDING.
             # The last check takes care of this case.
-            if torrent['is_seed'] and ((tryFloat(torrent['ratio']) < tryFloat(torrent['stop_ratio'])) or (tryFloat(torrent['stop_ratio']) <= 0)):
+            if torrent['is_seed'] and ((tryFloat(torrent['ratio']) < tryFloat(torrent['stop_ratio'])) or (tryFloat(torrent['stop_ratio']) < 0)):
                 # We have torrent['seeding_time'] to work out what the seeding time is, but we do not
                 # have access to the downloader seed_time, as with deluge we have no way to pass it
                 # when the torrent is added. So Deluge will only look at the ratio.


### PR DESCRIPTION
Changed the stop_ratio check to become "smaller than", instead of "smaller than or equal to" 0.

### Description of what this fixes:
The PR [#5740](https://github.com/CouchPotato/CouchPotatoServer/pull/5740) added a check mechanism in order to seed forever using Deluge. This is done by checking the torrent object's stop_ratio being non-positive (<=0). However, user can legitimately want to not seed at all, in which case he/she will set the stop_ratio in Deluge to 0. When the torrent finishes, it is paused by Deluge, but CouchPotato still thinks it is being seeded, due to the conditional statement in this line, thus it is marked as "seeding". In this state, renamer will not be triggered and downloaded files are not processed further.

In this PR, I removed the "equal to" part from the tryFloat(torrent['stop_ratio']) <= 0, so that if stop at ratio setting is set to 0, it is parsed as "no seeding". Users who would like to seed indefinitely can still set their stop ratio to be less than 0 and still get the same response. There might be a more clever solution than mine, so feel free to contribute. As it stands, my PR will affect people using Deluge with stop_ratio set to 0 for infinite seeding, but this can be easily fixed by setting stop ratio to a negative number.

PS: Tested and confirmed working

### Related issues:

