### PR TITLE
Fixes instances were getQuality returns null instead of empty object

### DIFF
--- a/couchpotato/core/plugins/quality/static/quality.js
+++ b/couchpotato/core/plugins/quality/static/quality.js
@@ -31,9 +31,9 @@ var QualityBase = new Class({
 
 	getQuality: function(identifier){
 		try {
-			return this.qualities.filter(function(q){
+			return (this.qualities.filter(function(q){
 				return q.identifier == identifier;
-			}).pick();
+			}).pick() || {});
 		}
 		catch(e){}
 


### PR DESCRIPTION
### Description of what this fixes:
...
In some cases, it appears that getQuality() can sometimes not match any existing objects in the array data, when this happens, it returns null instead of {} which the rest of the code expects. This causes the UI to fail to load leaving a blank page in the browser.