### PR TITLE
Extend ignore patterns

### DIFF
--- a/couchpotato/core/plugins/scanner.py
+++ b/couchpotato/core/plugins/scanner.py
@@ -28,6 +28,7 @@ class Scanner(Plugin):
                        '_failed_rename_', '.appledouble', '.appledb', '.appledesktop', os.path.sep + '._', '.ds_store', 'cp.cpnfo',
                        'thumbs.db', 'ehthumbs.db', 'desktop.ini']  # unpacking, smb-crap, hidden files
     ignore_names = ['extract', 'extracting', 'extracted', 'movie', 'movies', 'film', 'films', 'download', 'downloads', 'video_ts', 'audio_ts', 'bdmv', 'certificate']
+    ignored_extensions = ['ignore', 'lftp-pget-status']
     extensions = {
         'movie': ['mkv', 'wmv', 'avi', 'mpg', 'mpeg', 'mp4', 'm2ts', 'iso', 'img', 'mdf', 'ts', 'm4v', 'flv'],
         'movie_extra': ['mds'],
@@ -225,12 +226,12 @@ class Scanner(Plugin):
                 group['unsorted_files'].extend(found_files)
                 leftovers = leftovers - found_files
 
-                has_ignored += 1 if ext == 'ignore' else 0
+                has_ignored += 1 if ext in self.ignored_extensions else 0
 
             if has_ignored == 0:
                 for file_path in list(group['unsorted_files']):
                     ext = getExt(file_path)
-                    has_ignored += 1 if ext == 'ignore' else 0
+                    has_ignored += 1 if ext in self.ignored_extensions else 0
 
             if has_ignored > 0:
                 ignored_identifiers.append(identifier)


### PR DESCRIPTION
### Description of what this fixes:
Some want to synchronize files between a download server and storage server
hosting the couch potato instance. The renaming plugin does copy files when
file being available regardless the synchronization status, resulting in
corrupted files in destination folder. Files are not copied if a file with
extension .ignored is present. This extend at the moment the ignored extensions
to support common lftp temporary file. This way files get only copied once
synchronization is ended.
In the future this could be extended to have this extension list a configurable
option in the settings.

### Related issues:
Can't open an issue on GH, as no tab is available :/
