### PR TITLE
Update README.md OS X dependency instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ OS X:
 
 * If you're on Leopard (10.5) install Python 2.6+: [Python 2.6.5](http://www.python.org/download/releases/2.6.5/)
 * Install [GIT](http://git-scm.com/)
-* Install [LXML](http://lxml.de/installation.html) for better/faster website scraping 
+* Install [LXML](http://lxml.de/installation.html) with `easy_install lxml`
+* Install [PyOpenSSL](https://pypi.python.org/pypi/pyOpenSSL) with `easy_install pyopenssl`
 * Open up `Terminal`
 * Go to your App folder `cd /Applications`
 * Run `git clone https://github.com/CouchPotato/CouchPotatoServer.git`


### PR DESCRIPTION
### Description of what this fixes:

This should help OS X users who were installing dependencies with `sudo` which breaks CP's ability to scan some trackers (PassThePopcorn, in my tests).

The [LXML](http://lxml.de/installation.html) site says to install with `sudo pip` or `sudo port` which works, but apparently not in a way that's usable/reachable by CouchPotato.

Fixes this vague (to me) error:

```
[edia._base.providers.base] Failed to login PassThePopcorn: Traceback (most recent call last):
File "/Applications/CouchPotatoServer/couchpotato/core/media/_base/providers/base.py", line 163, in login
output = self.urlopen(self.urls['login'], data = self.getLoginParams())
File "/Applications/CouchPotatoServer/couchpotato/core/plugins/base.py", line 221, in urlopen
response = r.request(method, url, **kwargs)
File "/Applications/CouchPotatoServer/libs/requests/sessions.py", line 469, in request
resp = self.send(prep, **send_kwargs)
File "/Applications/CouchPotatoServer/libs/requests/sessions.py", line 577, in send
r = adapter.send(request, **kwargs)
File "/Applications/CouchPotatoServer/libs/requests/adapters.py", line 371, in send
timeout=timeout
File "/Applications/CouchPotatoServer/libs/requests/packages/urllib3/connectionpool.py", line 544, in urlopen
body=body, headers=headers)
File "/Applications/CouchPotatoServer/libs/requests/packages/urllib3/connectionpool.py", line 344, in _make_request
self._raise_timeout(err=e, url=url, timeout_value=conn.timeout)
File "/Applications/CouchPotatoServer/libs/requests/packages/urllib3/connectionpool.py", line 314, in _raise_timeout
if 'timed out' in str(err) or 'did not complete (read)' in str(err): # Python 2.6
TypeError: __str__ returned non-string (type Error)
```

Also fixes this SSL error happening inside `libs/requests/packages/urllib3/connectionpool.py`

```
[hpotato.core.plugins.base] Failed opening url in PassThePopcorn: https://passthepopcorn.me/ajax.php?action=login Traceback (most recent call last): ConnectionError: (<requests.packages.urllib3.connectionpool.HTTPSConnectionPool object at 0x10adcad90>, '/ajax.php?action=login', "[('SSL routines', 'SSL23_GET_SERVER_HELLO', 'sslv3 alert handshake failure')]")
```
