### PR TITLE
Fix a bug in quality.single that led to exceptions

### DIFF
--- a/couchpotato/core/plugins/quality/main.py
+++ b/couchpotato/core/plugins/quality/main.py
@@ -114,7 +114,12 @@ class QualityPlugin(Plugin):
         db = get_db()
         quality_dict = {}
 
-        quality = db.get('quality', identifier, with_doc = True)['doc']
+        try:
+            quality = db.get('quality', identifier, with_doc = True)['doc']
+        except RecordNotFound:
+            log.error("Unable to find '%s' in the quality DB", indentifier)
+            quality = None
+
         if quality:
             quality_dict = mergeDicts(self.getQuality(quality['identifier']), quality)
 


### PR DESCRIPTION
When the DB was unable to find a quality for the identifier, a
RecordNotFound exception was raised, leading to an exception in the
event caller because the quality_dict was not returned. This now sets
the quality to None and hands off to the event caller.

### Description of what this fixes:

```
02-25 08:37:06 ERROR [   couchpotato.core.event] Error in event "quality.single", that wasn't caught: Traceback (most recent call last):
  File "/Applications/CouchPotato.app/CouchPotato-3.0.1.macosx-10_6-intel/CouchPotato.app/Contents/Resources/lib/python2.7/couchpotato/core/event.py", line 15, in runHandler
  File "/Applications/CouchPotato.app/CouchPotato-3.0.1.macosx-10_6-intel/CouchPotato.app/Contents/Resources/lib/python2.7/couchpotato/core/plugins/quality/main.py", line 115, in single
  File "/Applications/CouchPotato.app/CouchPotato-3.0.1.macosx-10_6-intel/CouchPotato.app/Contents/Resources/lib/python2.7/libs/CodernityDB/database_super_thread_safe.py", line 43, in _inner
  File "/Applications/CouchPotato.app/CouchPotato-3.0.1.macosx-10_6-intel/CouchPotato.app/Contents/Resources/lib/python2.7/libs/CodernityDB/database.py", line 944, in get
RecordNotFound: Not found                                                                                                            encoding=UTF-8 debug=True args=['--quiet'] app_dir=/Applications/CouchPotato.app/CouchPotato-3.0.1.macosx-10_6-intel/CouchPotato.app/Contents/Resources/lib/python2.7 data_dir=/Users/mediauser/Library/Application Support/CouchPotato desktop=<__main__.CouchPotatoApp; proxy of <Swig Object of type 'wxPyApp *' at 0x100347560> > options=Namespace(config_file='/Users/mediauser/Library/Application Support/CouchPotato/settings.conf', console_log=False, daemon=False, data_dir=None, debug=False, pid_file='/Users/mediauser/Library/Application Support/CouchPotato/couchpotato.pid', quiet=True)
02-25 08:37:06 DEBUG [   couchpotato.core.event] Assume disabled eventhandler for: quality.single                                    02-25 08:37:06 ERROR [   couchpotato.core.event] Error in event "movie.searcher.single", that wasn't caught: Traceback (most recent call last):                                                                                                                             File "/Applications/CouchPotato.app/CouchPotato-3.0.1.macosx-10_6-intel/CouchPotato.app/Contents/Resources/lib/python2.7/couchpotato/core/event.py", line 15, in runHandler                                                                                               File "/Applications/CouchPotato.app/CouchPotato-3.0.1.macosx-10_6-intel/CouchPotato.app/Contents/Resources/lib/python2.7/couchpotato/core/media/movie/searcher.py", line 200, in single                                                                                 TypeError: 'NoneType' object has no attribute '__getitem__'
encoding=UTF-8 debug=True args=['--quiet'] app_dir=/Applications/CouchPotato.app/CouchPotato-3.0.1.macosx-10_6-intel/CouchPotato.app/Contents/Resources/lib/python2.7 data_dir=/Users/mediauser/Library/Application Support/CouchPotato desktop=<__main__.CouchPotatoApp; proxy of <Swig Object of type 'wxPyApp *' at 0x100347560> > options=Namespace(config_file='/Users/mediauser/Library/Application Support/CouchPotato/settings.conf', console_log=False, daemon=False, data_dir=None, debug=False, pid_file='/Users/mediauser/Library/Application Support/CouchPotato/couchpotato.pid', quiet=True)
```
