### PR TITLE
Yts provider 720p 1080p (Revision - Fix)

### DIFF
--- a/couchpotato/core/media/_base/providers/torrent/yts.py
+++ b/couchpotato/core/media/_base/providers/torrent/yts.py
@@ -35,7 +35,7 @@ class Base(TorrentMagnetProvider):
 
                     t = movie['info']['original_title'].split(' ')
 
-                    if all(word in name for word in t):
+                    if all(word in name for word in t) and movie['info']['year'] == result['year']:
 
                         year = result['year']
                         detail_url = result['url']

--- a/couchpotato/core/media/_base/providers/torrent/yts.py
+++ b/couchpotato/core/media/_base/providers/torrent/yts.py
@@ -29,33 +29,35 @@ class Base(TorrentMagnetProvider):
             else:
                 result = data['data']['movies'][0]
                 name = result['title']
-                year = result['year']
-                detail_url = result['url']
 
+                if getTitle(movie) == name:
 
-                for torrent in result['torrents']:
-                    t_quality = torrent['quality']
+                    year = result['year']
+                    detail_url = result['url']
 
-                    if t_quality in quality['label']:
-                        hash = torrent['hash']
-                        size = tryInt(torrent['size_bytes'] / 1048576)
-                        seeders = tryInt(torrent['seeds'])
-                        leechers = tryInt(torrent['peers'])
-                        pubdate = torrent['date_uploaded']  # format: 2017-02-17 18:40:03
-                        pubdate = datetime.strptime(pubdate, '%Y-%m-%d %H:%M:%S')
-                        age = (datetime.now() - pubdate).days
+                    for torrent in result['torrents']:
+                        t_quality = torrent['quality']
 
-                        results.append({
-                            'id': random.randint(100, 9999),
-                            'name': '%s (%s) %s %s %s' % (name, year, 'YTS', t_quality, 'BR-Rip'),
-                            'url': self.make_magnet(hash, name),
-                            'size': size,
-                            'seeders': seeders,
-                            'leechers': leechers,
-                            'age': age,
-                            'detail_url': detail_url,
-                            'score': 1
-                        })
+                        if t_quality in quality['label']:
+                            hash = torrent['hash']
+                            size = tryInt(torrent['size_bytes'] / 1048576)
+                            seeders = tryInt(torrent['seeds'])
+                            leechers = tryInt(torrent['peers'])
+                            pubdate = torrent['date_uploaded']  # format: 2017-02-17 18:40:03
+                            pubdate = datetime.strptime(pubdate, '%Y-%m-%d %H:%M:%S')
+                            age = (datetime.now() - pubdate).days
+
+                            results.append({
+                                'id': random.randint(100, 9999),
+                                'name': '%s (%s) %s %s %s' % (name, year, 'YTS', t_quality, 'BR-Rip'),
+                                'url': self.make_magnet(hash, name),
+                                'size': size,
+                                'seeders': seeders,
+                                'leechers': leechers,
+                                'age': age,
+                                'detail_url': detail_url,
+                                'score': 1
+                            })
 
         return
 

--- a/couchpotato/core/media/_base/providers/torrent/yts.py
+++ b/couchpotato/core/media/_base/providers/torrent/yts.py
@@ -25,7 +25,7 @@ class Base(TorrentMagnetProvider):
             movie_count = tryInt(data['data']['movie_count'])
 
             if movie_count == 0:
-                log.error('%s returned an error (search or tryInt() failed): %s', (self.getName(), data['error']))
+                log.error('%s returned an error (search or tryInt() failed): found no results', (self.getName()))
             else:
 
                 movie_results = data['data']['movies']

--- a/couchpotato/core/media/_base/providers/torrent/yts.py
+++ b/couchpotato/core/media/_base/providers/torrent/yts.py
@@ -17,7 +17,7 @@ class Base(TorrentMagnetProvider):
     }
 
     def _search(self, movie, quality, results):
-        limit = 5
+        limit = 10
         page = 1
         data = self.getJsonData(self.urls['search'] % (getTitle(movie), limit, page))
 

--- a/couchpotato/core/media/_base/providers/torrent/yts.py
+++ b/couchpotato/core/media/_base/providers/torrent/yts.py
@@ -33,7 +33,7 @@ class Base(TorrentMagnetProvider):
                     result = data['data']['movies'][i]
                     name = result['title']
 
-                    t = getTitle(movie).split(' ')
+                    t = movie['info']['original_title']
 
                     if all(word in name for word in t):
 

--- a/couchpotato/core/media/_base/providers/torrent/yts.py
+++ b/couchpotato/core/media/_base/providers/torrent/yts.py
@@ -33,7 +33,7 @@ class Base(TorrentMagnetProvider):
                     result = data['data']['movies'][i]
                     name = result['title']
 
-                    t = movie['info']['original_title']
+                    t = movie['info']['original_title'].split(' ')
 
                     if all(word in name for word in t):
 

--- a/couchpotato/core/media/_base/providers/torrent/yts.py
+++ b/couchpotato/core/media/_base/providers/torrent/yts.py
@@ -33,7 +33,9 @@ class Base(TorrentMagnetProvider):
                     result = data['data']['movies'][i]
                     name = result['title']
 
-                    if getTitle(movie) == name:
+                    t = getTitle(movie).split(' ')
+
+                    if all(word in name for word in t):
 
                         year = result['year']
                         detail_url = result['url']

--- a/couchpotato/core/media/_base/providers/torrent/yts.py
+++ b/couchpotato/core/media/_base/providers/torrent/yts.py
@@ -17,7 +17,7 @@ class Base(TorrentMagnetProvider):
     }
 
     def _search(self, movie, quality, results):
-        limit = 1
+        limit = 5
         page = 1
         data = self.getJsonData(self.urls['search'] % (getTitle(movie), limit, page))
 
@@ -27,37 +27,40 @@ class Base(TorrentMagnetProvider):
             if movie_count == 0:
                 log.error('%s returned an error (search or tryInt() failed): %s', (self.getName(), data['error']))
             else:
-                result = data['data']['movies'][0]
-                name = result['title']
 
-                if getTitle(movie) == name:
+                movie_results = data['data']['movies']
+                for i in range(0,len(movie_results)):
+                    result = data['data']['movies'][i]
+                    name = result['title']
 
-                    year = result['year']
-                    detail_url = result['url']
+                    if getTitle(movie) == name:
 
-                    for torrent in result['torrents']:
-                        t_quality = torrent['quality']
+                        year = result['year']
+                        detail_url = result['url']
 
-                        if t_quality in quality['label']:
-                            hash = torrent['hash']
-                            size = tryInt(torrent['size_bytes'] / 1048576)
-                            seeders = tryInt(torrent['seeds'])
-                            leechers = tryInt(torrent['peers'])
-                            pubdate = torrent['date_uploaded']  # format: 2017-02-17 18:40:03
-                            pubdate = datetime.strptime(pubdate, '%Y-%m-%d %H:%M:%S')
-                            age = (datetime.now() - pubdate).days
+                        for torrent in result['torrents']:
+                            t_quality = torrent['quality']
 
-                            results.append({
-                                'id': random.randint(100, 9999),
-                                'name': '%s (%s) %s %s %s' % (name, year, 'YTS', t_quality, 'BR-Rip'),
-                                'url': self.make_magnet(hash, name),
-                                'size': size,
-                                'seeders': seeders,
-                                'leechers': leechers,
-                                'age': age,
-                                'detail_url': detail_url,
-                                'score': 1
-                            })
+                            if t_quality in quality['label']:
+                                hash = torrent['hash']
+                                size = tryInt(torrent['size_bytes'] / 1048576)
+                                seeders = tryInt(torrent['seeds'])
+                                leechers = tryInt(torrent['peers'])
+                                pubdate = torrent['date_uploaded']  # format: 2017-02-17 18:40:03
+                                pubdate = datetime.strptime(pubdate, '%Y-%m-%d %H:%M:%S')
+                                age = (datetime.now() - pubdate).days
+
+                                results.append({
+                                    'id': random.randint(100, 9999),
+                                    'name': '%s (%s) %s %s %s' % (name, year, 'YTS', t_quality, 'BR-Rip'),
+                                    'url': self.make_magnet(hash, name),
+                                    'size': size,
+                                    'seeders': seeders,
+                                    'leechers': leechers,
+                                    'age': age,
+                                    'detail_url': detail_url,
+                                    'score': 1
+                                })
 
         return
 

--- a/couchpotato/core/media/_base/providers/torrent/yts.py
+++ b/couchpotato/core/media/_base/providers/torrent/yts.py
@@ -25,7 +25,7 @@ class Base(TorrentMagnetProvider):
             movie_count = tryInt(data['data']['movie_count'])
 
             if movie_count == 0:
-                log.error('%s returned an error (search or tryInt() failed): found no results', (self.getName()))
+                log.debug('%s - found no results', (self.getName()))
             else:
 
                 movie_results = data['data']['movies']


### PR DESCRIPTION
### Description of what this fixes:
When searching for Avatar 4 (2022) it found Avatar (2009) releases.
I added a name check on the releases the provider finds. Also increasing the limit of results it may parse, just to be sure it won't miss a release.

@ward0 found this bug and reported it on my original pull request #7186

### Limitations
Same limitations as mentioned in #7186 

### Testing
Tested the Avatar problem and it was fixed.  
Tested with Deadpool (2016) and Deadpool 2 (2018) - working.