### PR TITLE
Update ThePirateBay mirrors

### DIFF
--- a/couchpotato/core/media/_base/providers/torrent/thepiratebay.py
+++ b/couchpotato/core/media/_base/providers/torrent/thepiratebay.py
@@ -25,35 +25,7 @@ class Base(TorrentMagnetProvider):
     http_time_between_calls = 0
 
     proxy_list = [
-        'https://thepiratebay.mn',
-        'https://thepiratebay.gd',
-        'https://thepiratebay.la',
-        'https://pirateproxy.sx',
-        'https://piratebay.host',
-        'https://thepiratebay.expert',
-        'https://pirateproxy.wf',
-        'https://pirateproxy.tf',
-        'https://urbanproxy.eu',
-        'https://pirate.guru',
-        'https://piratebays.co',
-        'https://pirateproxy.yt',
-        'https://thepiratebay.uk.net',
-        'https://tpb.ninja',
-        'https://thehiddenbay.me',
-        'https://ukunlocked.com',
-        'https://thebay.tv',
-        'https://tpb.freed0m4all.net',
-        'https://piratebays.eu',
-        'https://thepirateproxy.co',
-        'https://thepiratebayz.com',
-        'https://zaatoka.eu',
-        'https://piratemirror.net',
-        'https://theproxypirate.pw',
-        'https://torrentdr.com',
-        'https://tpbproxy.co',
-        'https://arrr.xyz',
-        'https://www.cleantpbproxy.com',
-        'http://tpb.dashitz.com',
+        'https://thepiratebay.org',
     ]
 
     def __init__(self):


### PR DESCRIPTION
Add thepiratebay.org as a mirror and delete the old mirrors that no longer work.


### Description of what this fixes:

> ERROR
[se.providers.torrent.base] No ThePirateBay proxies left, please add one in settings, or let us know which one to add on the forum.

### Related issues:

Supposedly #7000 fixes this as well but it has way too many commits. Proposing closing that PR in favor of this one.