### PR TITLE
Changed where to look for matches for Bit-HDTV due to site changes

### DIFF
--- a/couchpotato/core/media/_base/providers/torrent/bithdtv.py
+++ b/couchpotato/core/media/_base/providers/torrent/bithdtv.py
@@ -42,7 +42,12 @@ class Base(TorrentProvider):
             html = BeautifulSoup(data, 'html.parser')
 
             try:
-                result_table = html.find('table', attrs = {'width': '750', 'class': ''})
+                result_tables = html.find_all('table', attrs = {'width': '750', 'class': ''})
+                if result_tables is None:
+                    return
+
+                result_table = result_tables[1]
+
                 if result_table is None:
                     return
 


### PR DESCRIPTION
Bit-HDTV changes their search web page and added some sticky torrents. All search matches against it. See 
https://www.bit-hdtv.com/forums/viewtopic.php?pid=96375

### Description of what this fixes:
Fixed search for Torrent provider Bit-HDTV

### Related issues:
Unknown
