### PR TITLE
Link to file bugs 404s

### DIFF
--- a/couchpotato/core/plugins/log/static/log.js
+++ b/couchpotato/core/plugins/log/static/log.js
@@ -250,7 +250,7 @@ Page.Log = new Class({
 					new Element('a.button', {
 						'target': '_blank',
 						'text': 'the contributing guide',
-						'href': 'https://github.com/CouchPotato/CouchPotatoServer/blob/develop/contributing.md'
+						'href': '#'
 					}),
 					new Element('span', {
 						'html': ' before posting, then copy the text below and <strong>FILL IN</strong> the dots.'


### PR DESCRIPTION
Obviously this shouldn't be merged, but I'm not sure how else to bring attention to this since I can't file an issue.

Access the issue URL results in a 404 since issues appears to be not public or blocked?

If this is the case then filing issues from within the CouchPotato UI should probably be revisted.

![image](https://cloud.githubusercontent.com/assets/27749188/25159025/b79360a4-247a-11e7-8775-b4df6ded8cf4.png)
