### PR TITLE
Report Issue Link 404s

### DIFF
--- a/couchpotato/core/plugins/log/static/log.js
+++ b/couchpotato/core/plugins/log/static/log.js
@@ -262,7 +262,7 @@ Page.Log = new Class({
 				new Element('a.button', {
 					'target': '_blank',
 					'text': 'Create a new issue on GitHub with the text above',
-					'href': '$',
+					'href': '#',
 					'events': {
 						'click': function(e){
 							(e).stop();

--- a/couchpotato/core/plugins/log/static/log.js
+++ b/couchpotato/core/plugins/log/static/log.js
@@ -262,7 +262,7 @@ Page.Log = new Class({
 				new Element('a.button', {
 					'target': '_blank',
 					'text': 'Create a new issue on GitHub with the text above',
-					'href': 'https://github.com/CouchPotato/CouchPotatoServer/issues/new',
+					'href': '$',
 					'events': {
 						'click': function(e){
 							(e).stop();


### PR DESCRIPTION
Obviously this shouldn't be merged, but I'm not sure how else to bring attention to this since I can't file an issue.

Access the issue URL results in a 404 since issues appears to be not public or blocked?

If this is the case then filing issues from within the CouchPotato UI should probably be revisted.

![](https://cloud.githubusercontent.com/assets/27749188/25159025/b79360a4-247a-11e7-8775-b4df6ded8cf4.png)