### PR TITLE
Fix Letterboxd integration and add multi-page support

### DIFF
--- a/couchpotato/core/media/movie/providers/automation/letterboxd.py
+++ b/couchpotato/core/media/movie/providers/automation/letterboxd.py
@@ -13,7 +13,7 @@ autoload = 'Letterboxd'
 
 class Letterboxd(Automation):
 
-    url = 'http://letterboxd.com/%s/watchlist/'
+    url = 'http://letterboxd.com/%s/watchlist/page/%d/'
     pattern = re.compile(r'(.*)\((\d*)\)')
 
     interval = 1800
@@ -46,18 +46,29 @@ class Letterboxd(Automation):
             if not enablers[index]:
                 continue
 
-            soup = BeautifulSoup(self.getHTMLData(self.url % username))
+            soup = BeautifulSoup(self.getHTMLData(self.url % (username, 1)))
 
-            for movie in soup.find_all('li', attrs = {'class': 'poster-container'}):
-                img = movie.find('img')
-                title = img.get('alt')
+            pagination_items = soup.find_all('li', attrs={'class': 'paginate-page'})
+            pages = range(1, len(pagination_items) + 1) if pagination_items else [1]
 
-                movies.append({
-                    'title': title
-                })
+            for page in pages:
+                soup = BeautifulSoup(self.getHTMLData(self.url % (username, page)))
+                movies += self.getMoviesFromHTML(soup)
 
         return movies
 
+    def getMoviesFromHTML(self, html):
+        movies = []
+
+        for movie in html.find_all('li', attrs={'class': 'poster-container'}):
+            img = movie.find('img')
+            title = img.get('alt')
+
+            movies.append({
+                'title': title
+            })
+
+        return movies
 
 config = [{
     'name': 'letterboxd',

--- a/couchpotato/core/media/movie/providers/automation/letterboxd.py
+++ b/couchpotato/core/media/movie/providers/automation/letterboxd.py
@@ -49,7 +49,7 @@ class Letterboxd(Automation):
             soup = BeautifulSoup(self.getHTMLData(self.url % username))
 
             for movie in soup.find_all('li', attrs = {'class': 'poster-container'}):
-                img = movie.find('img', movie)
+                img = movie.find('img')
                 title = img.get('alt')
 
                 movies.append({

--- a/couchpotato/core/media/movie/providers/automation/letterboxd.py
+++ b/couchpotato/core/media/movie/providers/automation/letterboxd.py
@@ -48,8 +48,9 @@ class Letterboxd(Automation):
 
             soup = BeautifulSoup(self.getHTMLData(self.url % (username, 1)))
 
-            pagination_items = soup.find_all('li', attrs={'class': 'paginate-page'})
-            pages = range(1, len(pagination_items) + 1) if pagination_items else [1]
+            pagination = soup.find_all('li', attrs={'class': 'paginate-page'})
+            number_of_pages = tryInt(pagination[-1].find('a').get_text()) if pagination else 1
+            pages = range(1, number_of_pages)
 
             for page in pages:
                 soup = BeautifulSoup(self.getHTMLData(self.url % (username, page)))


### PR DESCRIPTION
Letterboxd integragion was broken, this is fixed in the first commit.

The second commit adds support for multiple pages. When a watchlist (like for example https://letterboxd.com/pindab0ter/watchlist/) has multiple pages, only the first page would be scraped.

I have not managed to figure out how to properly develop and test for CouchPotato, I also think I might have not adhered to the style.

Please test if this works and give feedback on what needs to be improved/changed before it can be merged.