### PR TITLE
Convert movie attribute to string before checking it equals 'n/a'

### DIFF
--- a/couchpotato/core/media/movie/providers/info/omdbapi.py
+++ b/couchpotato/core/media/movie/providers/info/omdbapi.py
@@ -88,7 +88,7 @@ class OMDBAPI(MovieProvider):
 
             tmp_movie = movie.copy()
             for key in tmp_movie:
-                if tmp_movie.get(key).lower() == 'n/a':
+                if repr(tmp_movie.get(key)).lower() == 'n/a':
                     del movie[key]
 
             year = tryInt(movie.get('Year', ''))


### PR DESCRIPTION
This is failing when the attribute is a list. Error messages of 'list does not have lower() attribute.

### Description of what this fixes:
...

### Related issues:
...
