### PR TITLE
Prevent removal of download if disk is full.

### DIFF
--- a/couchpotato/core/downloaders/utorrent.py
+++ b/couchpotato/core/downloaders/utorrent.py
@@ -176,7 +176,7 @@ class uTorrent(DownloaderBase):
                 status = 'busy'
                 if (torrent[1] & self.status_flags['STARTED'] or torrent[1] & self.status_flags['QUEUED']) and torrent[4] == 1000:
                     status = 'seeding'
-                elif torrent[1] & self.status_flags['ERROR']:
+                elif torrent[1] & self.status_flags['ERROR'] and 'There is not enough space on the disk' not in torrent[21]:
                     status = 'failed'
                 elif torrent[4] == 1000:
                     status = 'completed'


### PR DESCRIPTION
### Description of what this fixes:
Good torrents are skipped, anything downloaded prior to being stalled is thrown away meaning the download has to start again.
Download hasn't failed but rather been temporarily stalled. It should leave the download a lone until a proper error that cannot be fixed.
If the disk is full it will also likely prevent any other downloads as well so even more reason to leave it alone.
This prevents waste in data but more importantly prevents waste of time by not having to restart downloads.