### PR TITLE
torrentday has depcreated classic URL

### DIFF
--- a/couchpotato/core/media/_base/providers/torrent/torrentday.py
+++ b/couchpotato/core/media/_base/providers/torrent/torrentday.py
@@ -9,12 +9,12 @@ log = CPLog(__name__)
 class Base(TorrentProvider):
 
     urls = {
-        'test': 'https://classic.torrentday.com/',
-        'login': 'https://classic.torrentday.com/torrents/',
-        'login_check': 'https://classic.torrentday.com/userdetails.php',
-        'detail': 'https://classic.torrentday.com/details.php?id=%s',
-        'search': 'https://classic.torrentday.com/V3/API/API.php',
-        'download': 'https://classic.torrentday.com/download.php/%s/%s',
+        'test': 'https://www.torrentday.com/',
+        'login': 'https://www.torrentday.com/torrents/',
+        'login_check': 'https://www.torrentday.com/userdetails.php',
+        'detail': 'https://www.torrentday.com/details.php?id=%s',
+        'search': 'https://www.torrentday.com/V3/API/API.php',
+        'download': 'https://www.torrentday.com/download.php/%s/%s',
     }
 
     http_time_between_calls = 1  # Seconds
@@ -86,7 +86,7 @@ config = [{
             'tab': 'searcher',
             'list': 'torrent_providers',
             'name': 'TorrentDay',
-            'description': '<a href="https://classic.torrentday.com/" target="_blank">TorrentDay</a>',
+            'description': '<a href="https://www.torrentday.com/" target="_blank">TorrentDay</a>',
             'wizard': True,
             'icon': 'iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAC5ElEQVQ4y12TXUgUURTH//fO7Di7foeQJH6gEEEIZZllVohfSG/6UA+RSFAQQj74VA8+Bj30lmAlRVSEvZRfhNhaka5ZUG1paKaW39tq5O6Ou+PM3M4o6m6X+XPPzD3zm/+dcy574r515WfIW8CZBM4YAA5Gc/aQC3yd7oXYEONcsISE5dTDh91HS0t7FEWhBUAeN9ynV/d9qJAgE4AECURAcVsGlCCnly26LMA0IQwTa52dje3d3e3hcPi8qqrrMjcVYI3EHCQZlkFOHBwR2QHh2ASAAIJxWGAQEDxjePhs3527XjJwnb37OHBq0T+Tyyjh+9KnEzNJ7nouc1Q/3A3HGsOvnJy+PSUlj81w2Lny9WuJ6+3AmTjD4HOcrdR2dWXLRQePvyaSLfQOPMPC8mC9iHCsOxSyzJCelzdSXlNzD5ujpb25Wbfc/XXJemTXF4+nnCNq+AMLe50uFfEJTiw4GXSFtiHL0SnIq66+p0kSArqO+eH3RdsAv9+f5vW7L7GICq6rmM8XBCAXlBw90rOyxibn5yzfkg/L09M52/jxqdESaIrBXHYZZbB1GX8cEpySxKIB8S5XcOnvqpli1zuwmrTtoLjw5LOK/eeuWsE4JH5IRPaPZKiKigmPp+5pa+u1aEjIMhEgrRkmi9mgxGUhM7LNJSzOzsE3+cOeExovXOjdytE0LV4zqNZUtV0uZzAGoGkhDH/2YHZiErmv4uyWQnZZWc+hoqL3WzlTExN5hhA8IEwkZWZOxwB++30YG/9GkYCPvqAaHAW5uWPROW86OmqCprUR7z1yZDAGQNuCvkoB/baIKUBWMTYymv+gra3eJNvjXu+B562tFyXqTJ6YuHK8rKwvBmC3vR7cOCPQLWFz8LnfXWUrJo9U19BwMyUlJRjTSMJ2ENxUiGxq9KXQfwqYlnWstvbR5aamG9g0uzM8Q4OFt++3NNixQ2NgYmeN03FOTUv7XVpV9aKisvLl1vN/WVhNc/Fi1NEAAAAASUVORK5CYII=',
             'options': [


### PR DESCRIPTION
### Description of what this fixes:
the "classic" url for downloading torrent files from torrentday has been deprecated and has begun throwing 404's. As is, snatching is broken for torrentday. Changing the base_url's resolves this issue and allows snatching again.
