### PR TITLE
Update omdbapi.py

### DIFF
--- a/couchpotato/core/media/movie/providers/info/omdbapi.py
+++ b/couchpotato/core/media/movie/providers/info/omdbapi.py
@@ -19,7 +19,7 @@ class OMDBAPI(MovieProvider):
 
     urls = {
         'search': 'https://www.omdbapi.com/?apikey=%s&type=movie&%s',
-        'info': 'https://www.omdbapi.com/?apikiey=%s&type=movie&i=%s',
+        'info': 'https://www.omdbapi.com/?apikey=%s&type=movie&i=%s',
     }
 
     http_time_between_calls = 0
@@ -59,7 +59,8 @@ class OMDBAPI(MovieProvider):
             return {}
 
         cache_key = 'omdbapi.cache.%s' % identifier
-        cached = self.getCache(cache_key, self.urls['info'] % identifier, timeout = 3, headers = {'User-Agent': Env.getIdentifier()})
+        url = self.urls['info'] % (self.getApiKey(), identifier)
+        cached = self.getCache(cache_key, url, timeout = 3, headers = {'User-Agent': Env.getIdentifier()})
 
         if cached:
             result = self.parseMovie(cached)


### PR DESCRIPTION
Fixed API key support for OMDb

### Description of what this fixes:
```
File "/apps/couchpotato2/couchpotato/core/media/movie/providers/info/omdbapi.py", line 62, in getInfo
    cached = self.getCache(cache_key, self.urls['info'] % identifier, timeout = 3, headers = {'User-Agent': Env.getIdentifier()})
TypeError: not enough arguments for format string
```

### Related issues:
This is a new PR based on `CouchPotato:develop`. Credits to https://github.com/CouchPotato/CouchPotatoServer/pull/7217
