### PR TITLE
Update thepiratebay.py

### DIFF
--- a/couchpotato/core/media/movie/providers/torrent/thepiratebay.py
+++ b/couchpotato/core/media/movie/providers/torrent/thepiratebay.py
@@ -21,7 +21,7 @@ class ThePirateBay(MovieProvider, Base):
 
     def buildUrl(self, media, page, cats):
         return (
-            tryUrlencode('"%s"' % fireEvent('library.query', media, single = True)),
+            tryUrlencode('%s' % fireEvent('library.query', media, single = True)),
             page,
             ','.join(str(x) for x in cats)
         )


### PR DESCRIPTION
Remove the quotes around the search string to allow for results to be returned

### Description of what this fixes:
Removes quotes so that thepiratebay can return results. I have had several movies not be returned because of the quoting

### Related issues:
...
