### PR TITLE
Switch from qstatus (deprecated) to queue API call for SABnzbd

### DIFF
--- a/couchpotato/core/downloaders/sabnzbd.py
+++ b/couchpotato/core/downloaders/sabnzbd.py
@@ -100,7 +100,7 @@ class Sabnzbd(DownloaderBase):
 
             # the version check will work even with wrong api key, so we need the next check as well
             sab_data = self.call({
-                'mode': 'qstatus',
+                'mode': 'queue',
             })
             if not sab_data:
                 return False


### PR DESCRIPTION
@RuudBurger Will people that have the installer from https://couchpota.to/ also get this update?
Because we wanted to get rid of `qstatus` for a long time, but didn't because of CouchPotato.

(now correctly against `develop` and not `master`)