### PR TITLE
Dismiss details overlay when pressing escape

### DIFF
--- a/couchpotato/core/media/movie/_base/static/details.js
+++ b/couchpotato/core/media/movie/_base/static/details.js
@@ -77,7 +77,6 @@ var MovieDetails = new Class({
 				'class': parent.get('title') == t ? 'icon-ok' : ''
 			}));
 		});
-
 	},
 
 	addSection: function(name, section_el){
@@ -101,7 +100,7 @@ var MovieDetails = new Class({
 		var self = this;
 
 		self.el.addClass('show');
-
+		document.onkeyup = self.keyup.bind(self);
 		//if(!App.mobile_screen){
 		//	$(self.content).getElements('> .head, > .section').each(function(section, nr){
 		//		dynamics.css(section, {
@@ -130,12 +129,19 @@ var MovieDetails = new Class({
 
 	},
 
+	keyup: function(e) {
+		if (e.keyCode == 27 /* Esc */) {
+			this.close();
+		}
+	},
+
 	close: function(){
 		var self = this;
 
 		var ended = function() {
 			self.el.dispose();
 			self.overlay.removeEventListener('transitionend', ended);
+			document.onkeyup = null;
 		};
 		self.overlay.addEventListener('transitionend', ended, false);
 
@@ -165,5 +171,4 @@ var MovieDetails = new Class({
 
 		App.removeEvent('history.push', self.outer_click);
 	}
-
 });

--- a/couchpotato/static/scripts/combined.plugins.min.js
+++ b/couchpotato/static/scripts/combined.plugins.min.js
@@ -382,16 +382,23 @@ var MovieDetails = new Class({
     open: function() {
         var self = this;
         self.el.addClass("show");
+        document.onkeyup = self.keyup.bind(self);
         self.outer_click = function() {
             self.close();
         };
         App.addEvent("history.push", self.outer_click);
+    },
+    keyup: function(e) {
+        if (e.keyCode == 27) {
+            this.close();
+        }
     },
     close: function() {
         var self = this;
         var ended = function() {
             self.el.dispose();
             self.overlay.removeEventListener("transitionend", ended);
+            document.onkeyup = null;
         };
         self.overlay.addEventListener("transitionend", ended, false);
         self.el.removeClass("show");
@@ -3416,7 +3423,7 @@ var QualityBase = new Class({
         try {
             return this.qualities.filter(function(q) {
                 return q.identifier == identifier;
-            }).pick();
+            }).pick() || {};
         } catch (e) {}
         return {};
     },


### PR DESCRIPTION
### Description of what this fixes:
 I noticed myself constantly pressing escape to dismiss the movie details overlay, so created a PR for this.

Tested in Google Chrome, Firefox, and Safari. In Firefox and Safari a side effect is that when adding a movie and one of the movie title or quality select inputs is expanded, the overlay closes when you might expect the select to collapse when pressing escape.

