### PR TITLE
Add support for 2160p quality

### DIFF
--- a/couchpotato/core/media/movie/providers/torrent/alpharatio.py
+++ b/couchpotato/core/media/movie/providers/torrent/alpharatio.py
@@ -19,7 +19,7 @@ class AlphaRatio(MovieProvider, Base):
 
     cat_ids = [
         ([7, 9], ['bd50']),
-        ([7, 9], ['720p', '1080p']),
+        ([7, 9], ['720p', '1080p', '2160p']),
         ([6, 8], ['dvdr']),
         ([6, 8], ['brrip', 'dvdrip']),
     ]


### PR DESCRIPTION
### Description of what this fixes:

When using AlphaRatio with a 2160p quality request, this would previously default to using the the cat_backup_id category, which is MoviesSD, rather than using MoviesHD.