### PR TITLE
BinSearch API update fixes

### DIFF
--- a/couchpotato/core/media/movie/providers/nzb/binsearch.py
+++ b/couchpotato/core/media/movie/providers/nzb/binsearch.py
@@ -21,7 +21,7 @@ class BinSearch(MovieProvider, Base):
             'adv_sort': 'date',
             'adv_col': 'on',
             'adv_nfo': 'on',
-            'minsize': quality.get('size_min'),
-            'maxsize': quality.get('size_max'),
+            'xminsize': quality.get('size_min'),
+            'xmaxsize': quality.get('size_max'),
         })
         return query


### PR DESCRIPTION
BinSearch API update. Fixes ERROR [hpotato.core.plugins.base] Failed
opening url in BinSearch.

Original solved by DmcDenissen ( https://forums.freenas.org/index.php?threads/couchpotato-binsearch-returning-403-forbidden-solution.50719/ ).