### PR TITLE
Don't rename subtitles when there's only one language

### DIFF
--- a/couchpotato/core/plugins/renamer.py
+++ b/couchpotato/core/plugins/renamer.py
@@ -459,7 +459,7 @@ class Renamer(Plugin):
                             )
 
                             # Don't add language if multiple languages in 1 subtitle file
-                            if len(sub_langs) == 1:
+                            if len(sub_langs) != 1:
                                 sub_suffix = '%s.%s' % (sub_langs[0], replacements['ext'])
 
                                 # Don't add language to subtitle file it it's already there


### PR DESCRIPTION
### Description of what this fixes:

I looked into the issue I had with Plex not detecting subtitles.

Soon I found out CouchPotato is renaming a pair of idx/sub to MovieName.idx and MovieName.en.sub, even though they are the only files.
