### PR TITLE
Proper fix for kodi metadata release date

### DIFF
--- a/couchpotato/core/media/movie/providers/metadata/xbmc.py
+++ b/couchpotato/core/media/movie/providers/metadata/xbmc.py
@@ -111,9 +111,9 @@ class XBMC(MovieMetaData):
         try:
             if movie_info.get('released'):
                 el = SubElement(nfoxml, 'premiered')
-                el.text = time.strftime('%Y:%m:%d', time.strptime(movie_info.get('released'), '%d %b %Y')
+                el.text = time.strftime('%Y-%m-%d', time.strptime(movie_info.get('released'), '%d %b %Y')
         except:
-            log.debug('Failed to parse release date %s: %s', movie_info.get('released'), traceback.format_exc())
+            log.debug('Failed to parse release date %s: %s', (movie_info.get('released'), traceback.format_exc()))
 
         # Rating
         for rating_type in ['imdb', 'rotten', 'tmdb']:


### PR DESCRIPTION
### Description of what this fixes:
Use dashes instead of quotes when reformatting the date. 
Also fixed the debug log, as I wrongly assumed default python syntax in the logger (tuple instead of *args).

### Related issues:
https://github.com/CouchPotato/CouchPotatoServer/pull/7247

For those who want to fix their existing library, you may use this script.

```
import os                                                                                                                   
import time                                                                                                                 
import xml.etree.ElementTree as ET                                                                                          
                                                                                                                            
def fixdate(filename):                                                                                                      
    tree = ET.parse(filename)                                                                                               
    root = tree.getroot()                                                                                                   
    for child in root:                                                                                                      
        if child.tag == 'premiered':                                                                                        
            date = child.text                                                                                               
            if '-' not in date:                                                                                             
                print filename.split(os.sep)[-1]                                                                            
                if ' ' in date:                                                                                             
                    gooddate = time.strftime('%Y-%m-%d', time.strptime(date, '%d %b %Y'))                                   
                elif ':' in date:                                                                                           
                    gooddate = date.replace(':', '-')                                                                       
                print date, gooddate                                                                                        
                child.text = gooddate                                                                                       
                tree.write(filename)                                                                                        
                                                                                                                            
MOVIEDIR = '/path/to/movies'                                                                      
for f in os.listdir(MOVIEDIR):                                                                                              
    for ff in os.listdir(os.path.join(MOVIEDIR, f)):                                                                        
        if ff.endswith('.nfo') and not ff.endswith('.orig.nfo'):                                                            
           fullpath = os.path.join(MOVIEDIR, f, ff)                                                                         
           fixdate(fullpath)   

```