### PR TITLE
Update scanner.py

### DIFF
--- a/couchpotato/core/plugins/scanner.py
+++ b/couchpotato/core/plugins/scanner.py
@@ -30,7 +30,7 @@ class Scanner(Plugin):
     ignore_names = ['extract', 'extracting', 'extracted', 'movie', 'movies', 'film', 'films', 'download', 'downloads', 'video_ts', 'audio_ts', 'bdmv', 'certificate']
     ignored_extensions = ['ignore', 'lftp-pget-status']
     extensions = {
-        'movie': ['mkv', 'wmv', 'avi', 'mpg', 'mpeg', 'mp4', 'm2ts', 'iso', 'img', 'mdf', 'ts', 'm4v', 'flv'],
+        'movie': ['mkv', 'wmv', 'avi', 'mpg', 'mpeg', 'mp4', 'm2ts', 'iso', 'img', 'mdf', 'ts', 'm4v', 'flv', 'mov'],
         'movie_extra': ['mds'],
         'dvd': ['vts_*', 'vob'],
         'nfo': ['nfo', 'txt', 'tag'],


### PR DESCRIPTION
Add support of .mov extension in the renamer
Based on this old post in the forum: https://couchpota.to/forum/viewtopic.php?f=5&t=4642&p=22300#p22313
Tested with single .mov file that has been correctly processed by the renamer
