### PR TITLE
Change search term for 2160p material from PTP provider

### DIFF
--- a/couchpotato/core/downloaders/sabnzbd.py
+++ b/couchpotato/core/downloaders/sabnzbd.py
@@ -100,7 +100,7 @@ class Sabnzbd(DownloaderBase):
 
             # the version check will work even with wrong api key, so we need the next check as well
             sab_data = self.call({
-                'mode': 'qstatus',
+                'mode': 'queue',
             })
             if not sab_data:
                 return False

--- a/couchpotato/core/media/movie/providers/metadata/xbmc.py
+++ b/couchpotato/core/media/movie/providers/metadata/xbmc.py
@@ -112,9 +112,9 @@ class XBMC(MovieMetaData):
         try:
             if movie_info.get('released'):
                 el = SubElement(nfoxml, 'premiered')
-                el.text = time.strftime('%Y:%m:%d', time.strptime(movie_info.get('released'), '%d %b %Y'))
+                el.text = time.strftime('%Y-%m-%d', time.strptime(movie_info.get('released'), '%d %b %Y'))
         except:
-            log.debug('Failed to parse release date %s: %s', movie_info.get('released'), traceback.format_exc())
+            log.debug('Failed to parse release date %s: %s', (movie_info.get('released'), traceback.format_exc()))
 
         # Rating
         for rating_type in ['imdb', 'rotten', 'tmdb']:

--- a/couchpotato/core/media/movie/providers/torrent/passthepopcorn.py
+++ b/couchpotato/core/media/movie/providers/torrent/passthepopcorn.py
@@ -10,7 +10,7 @@ autoload = 'PassThePopcorn'
 class PassThePopcorn(MovieProvider, Base):
 
     quality_search_params = {
-        '2160p': {'resolution': '4K'},
+        '2160p': {'resolution': '2160p'},
         'bd50': {'media': 'Blu-ray', 'format': 'BD50'},
         '1080p': {'resolution': '1080p'},
         '720p': {'resolution': '720p'},
@@ -25,7 +25,7 @@ class PassThePopcorn(MovieProvider, Base):
     }
 
     post_search_filters = {
-        '2160p': {'Resolution': ['4K']},
+        '2160p': {'Resolution': ['2160p']},
         'bd50': {'Codec': ['BD50']},
         '1080p': {'Resolution': ['1080p']},
         '720p': {'Resolution': ['720p']},


### PR DESCRIPTION
### Description of what this fixes:
The search term 4K does not garner any results from PTP, you need to use the term 2160p as this is the naming used on PTP.