### PR TITLE
Change search term for 2160p material from PTP provider

### DIFF
--- a/couchpotato/core/media/movie/providers/torrent/passthepopcorn.py
+++ b/couchpotato/core/media/movie/providers/torrent/passthepopcorn.py
@@ -10,7 +10,7 @@ autoload = 'PassThePopcorn'
 class PassThePopcorn(MovieProvider, Base):
 
     quality_search_params = {
-        '2160p': {'resolution': '4K'},
+        '2160p': {'resolution': '2160p'},
         'bd50': {'media': 'Blu-ray', 'format': 'BD50'},
         '1080p': {'resolution': '1080p'},
         '720p': {'resolution': '720p'},
@@ -25,7 +25,7 @@ class PassThePopcorn(MovieProvider, Base):
     }
 
     post_search_filters = {
-        '2160p': {'Resolution': ['4K']},
+        '2160p': {'Resolution': ['2160p']},
         'bd50': {'Codec': ['BD50']},
         '1080p': {'Resolution': ['1080p']},
         '720p': {'Resolution': ['720p']},


### PR DESCRIPTION
### Description of what this fixes:
PTP does not return any results when searching for the term 4K. PTP uses 2160p as search term for its 4K material and so, the search term needs to be changed.
