### PR TITLE
Fix Transmission basic authentication

### DIFF
--- a/couchpotato/core/downloaders/transmission.py
+++ b/couchpotato/core/downloaders/transmission.py
@@ -146,7 +146,7 @@ class Transmission(DownloaderBase):
                 """
                 https://trac.transmissionbt.com/browser/branches/2.8x/libtransmission/transmission.h#L1853
                 0 = Torrent is stopped
-                1 = Queued to check files 
+                1 = Queued to check files
                 2 = Checking files
                 3 = Queued to download
                 4 = Downloading
@@ -212,7 +212,7 @@ class TransmissionRPC(object):
         self.session = {}
         if username and password:
             password_manager = urllib2.HTTPPasswordMgrWithDefaultRealm()
-            password_manager.add_password(realm = 'Transmission', uri = self.url, user = username, passwd = password)
+            password_manager.add_password(realm = None, uri = self.url, user = username, passwd = password)
             opener = urllib2.build_opener(urllib2.HTTPBasicAuthHandler(password_manager))
             opener.addheaders = [('User-agent', 'couchpotato-transmission-client/1.0')]
             urllib2.install_opener(opener)


### PR DESCRIPTION
Hi.

CouchPotato keeps getting a `401 Unauthorized` error when connecting to Transmission behind an Apache reverse proxy with basic auth.

This little change fixes the issue for me.