### PR TITLE
Update torrentday.py

### DIFF
--- a/couchpotato/core/media/_base/providers/torrent/torrentday.py
+++ b/couchpotato/core/media/_base/providers/torrent/torrentday.py
@@ -14,7 +14,7 @@ class Base(TorrentProvider):
         'login_check': 'https://www.torrentday.com/userdetails.php',
         'detail': 'https://www.torrentday.com/details.php?id=%s',
         'search': 'https://www.torrentday.com/t.json',
-        'download': 'https://www.torrentday.com/download.php/%s/%s',
+        'download': 'https://www.torrentday.com/download.php/%s/%s.torrent',
     }
 
     http_time_between_calls = 1  # Seconds

--- a/couchpotato/core/media/_base/providers/torrent/torrentday.py
+++ b/couchpotato/core/media/_base/providers/torrent/torrentday.py
@@ -10,10 +10,10 @@ class Base(TorrentProvider):
 
     urls = {
         'test': 'https://www.torrentday.com/',
-        'login': 'https://www.torrentday.com/torrents/',
+        'login': 'https://www.torrentday.com/t',
         'login_check': 'https://www.torrentday.com/userdetails.php',
         'detail': 'https://www.torrentday.com/details.php?id=%s',
-        'search': 'https://www.torrentday.com/V3/API/API.php',
+        'search': 'https://www.torrentday.com/t.json',
         'download': 'https://www.torrentday.com/download.php/%s/%s',
     }
 
@@ -32,11 +32,9 @@ class Base(TorrentProvider):
         query = '"%s" %s' % (title, media['info']['year'])
 
         data = {
-            '/browse.php?': None,
-            'cata': 'yes',
-            'jxt': 8,
-            'jxw': 'b',
-            'search': query,
+            '11': 'on',
+            '48': 'on',
+            'q': query,
         }
 
         data = self.getJsonData(self.urls['search'], data = data, headers = self.getRequestHeaders())
@@ -45,13 +43,13 @@ class Base(TorrentProvider):
 
         for torrent in torrents:
             results.append({
-                'id': torrent['id'],
+                'id': torrent['t'],
                 'name': torrent['name'],
-                'url': self.urls['download'] % (torrent['id'], torrent['fname']),
-                'detail_url': self.urls['detail'] % torrent['id'],
+                'url': self.urls['download'] % (torrent['t'], torrent['name']),
+                'detail_url': self.urls['detail'] % torrent['t'],
                 'size': self.parseSize(torrent.get('size')),
-                'seeders': tryInt(torrent.get('seed')),
-                'leechers': tryInt(torrent.get('leech')),
+                'seeders': tryInt(torrent.get('seeders')),
+                'leechers': tryInt(torrent.get('leechers')),
             })
 
     def getRequestHeaders(self):


### PR DESCRIPTION
Tried to fix the New json fetching Method on search. The New address it t.json.

I think this still misses something, but i'm not a pro coder by any means.

### Description of what this fixes:
- The old API link doesn't work anymore
- Tried simulating POST/GET, and 'id' has become 't'

Example of fetched from t.json:
```json
{
"t": 123123123,
"c": 48,
"size": 3237648014,
"files": 97,
"seeders": 521,
"leechers": 50,
"completed": 639,
"ctime": 1522959339,
"category": "Movies/x265",
"name": "Moviename 2017 BluRay 10Bit 1080p DD5 1 H265-d3g",
"imdb-id": "tt573xxxx"
}
```

### From log:
```
04-06 09:14:04 INFO
[hpotato.core.plugins.base] Opening url: post https://www.torrentday.com/t.json, data: ['11', 'q', '48', 'qf']
04-06 09:14:04 DEBUG
[hpotato.core.plugins.base] Waiting for TorrentDay, 1 seconds
04-06 09:14:05 DEBUG
[o.core.notifications.core] Getting messages with id: 4821638f-7373-4032-9e6f-8317b240bb8d
04-06 09:14:05 DEBUG
[o.core.notifications.core] Returning for 4821638f-7373-4032-9e6f-8317b240bb8d 0 messages
```
