### PR TITLE
allow watching of trailer in fullscreen in firefox

### DIFF
--- a/couchpotato/core/media/movie/_base/static/movie.actions.js
+++ b/couchpotato/core/media/movie/_base/static/movie.actions.js
@@ -424,7 +424,8 @@ MA.Trailer = new Class({
 		var self = this;
 
 		new Element('iframe', {
-			'src': 'https://www.youtube-nocookie.com/embed/'+self.video_id+'?rel=0&showinfo=0&autoplay=1&showsearch=0&iv_load_policy=3&vq=hd720'
+			'src': 'https://www.youtube-nocookie.com/embed/'+self.video_id+'?rel=0&showinfo=0&autoplay=1&showsearch=0&iv_load_policy=3&vq=hd720',
+			'allowfullscreen': 'true'
 		}).inject(self.container);
 	}
 

--- a/couchpotato/static/scripts/combined.plugins.min.js
+++ b/couchpotato/static/scripts/combined.plugins.min.js
@@ -1301,7 +1301,8 @@ MA.Trailer = new Class({
     watch: function() {
         var self = this;
         new Element("iframe", {
-            src: "https://www.youtube-nocookie.com/embed/" + self.video_id + "?rel=0&showinfo=0&autoplay=1&showsearch=0&iv_load_policy=3&vq=hd720"
+            src: "https://www.youtube-nocookie.com/embed/" + self.video_id + "?rel=0&showinfo=0&autoplay=1&showsearch=0&iv_load_policy=3&vq=hd720",
+			allowfullscreen: "true"
         }).inject(self.container);
     }
 });


### PR DESCRIPTION
### Description of what this fixes:
YouTube player for trailers is not allowed to be switched to fullscreen in Firefox without this attribute on the iframe.
