### PR TITLE
Added HTTPS and Port support to Plex notifications

### DIFF
--- a/couchpotato/core/notifications/plex/__init__.py
+++ b/couchpotato/core/notifications/plex/__init__.py
@@ -24,6 +24,19 @@ config = [{
                     'description': 'Hostname/IP, default localhost'
                 },
                 {
+                    'name': 'media_server_port',
+                    'label': 'Port',
+                    'default': '32400',
+                    'description': 'Connection tot he Media Server should use this port'
+                },
+                {
+                    'name': 'use_https',
+                    'label': 'Use HTTPS',
+                    'default': '0',
+                    'type': 'bool',
+                    'description': 'Connection to the Media Server should use HTTPS instead of HTTP'
+                },
+                {
                     'name': 'username',
                     'label': 'Username',
                     'default': '',

--- a/couchpotato/core/notifications/plex/server.py
+++ b/couchpotato/core/notifications/plex/server.py
@@ -38,7 +38,7 @@ class PlexServer(object):
         #Maintain support for older Plex installations without myPlex
         if not self.plex.conf('auth_token') and not self.plex.conf('username') and not self.plex.conf('password'):
             data = self.plex.urlopen('%s/%s' % (
-                self.createHost(self.plex.conf('media_server'), port = 32400),
+                self.createHost(self.plex.conf('media_server'), port = self.plex.conf('media_server_port'), use_https = self.plex.conf('use_https')),
                 path
             ))
         else:
@@ -71,7 +71,7 @@ class PlexServer(object):
 
             #Add X-Plex-Token header for myPlex support workaround
             data = self.plex.urlopen('%s/%s?X-Plex-Token=%s' % (
-                self.createHost(self.plex.conf('media_server'), port = 32400),
+                self.createHost(self.plex.conf('media_server'), port = self.plex.conf('media_server_port'), use_https = self.plex.conf('use_https')),
                 path,
                 self.plex.conf('auth_token')
             ))
@@ -139,9 +139,9 @@ class PlexServer(object):
 
         return True
 
-    def createHost(self, host, port = None):
+    def createHost(self, host, port = None, use_https = False):
 
-        h = cleanHost(host)
+        h = cleanHost(host, True, use_https)
         p = urlparse(h)
         h = h.rstrip('/')
 


### PR DESCRIPTION
### Description of what this fixes:
Plex server behind an alternate port and using HTTPS could not be reached for notifications. This adds two options to the setup for Plex notifications: Port and Use HTTPS.

Tested against local Plex as well as remote Plex installs.

### Related issues:
N/A
