### PR TITLE
Use python2

### DIFF
--- a/CouchPotato.py
+++ b/CouchPotato.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 from __future__ import print_function
 from logging import handlers
 from os.path import dirname


### PR DESCRIPTION
### Description of what this fixes:

Since CouchPotato is not Python 3 compatible, this makes sure the correct Python version is used. Even when /usr/bin/python is Python 3.