### PR TITLE
Respect minimal requirements in trakt automation

### DIFF
--- a/couchpotato/core/media/movie/providers/automation/base.py
+++ b/couchpotato/core/media/movie/providers/automation/base.py
@@ -71,7 +71,7 @@ class Automation(AutomationBase):
             log.info('ignoring %s as no rating is available for.', (movie['original_title']))
             return False
 
-        if movie['rating'] and movie['rating'].get('imdb'):
+        if movie['rating'] and type(movie['rating']) is not float and movie['rating'].get('imdb'):
             movie['votes'] = movie['rating']['imdb'][1]
             movie['rating'] = movie['rating']['imdb'][0]
 

--- a/couchpotato/core/media/movie/providers/automation/trakt/main.py
+++ b/couchpotato/core/media/movie/providers/automation/trakt/main.py
@@ -37,7 +37,7 @@ class TraktBase(Provider):
 class Trakt(Automation, TraktBase):
 
     urls = {
-        'watchlist': 'sync/watchlist/movies/',
+        'watchlist': 'sync/watchlist/movies?extended=full',
         'oauth': 'https://api.couchpota.to/authorize/trakt/',
         'refresh_token': 'https://api.couchpota.to/authorize/trakt_refresh/',
     }
@@ -79,7 +79,13 @@ class Trakt(Automation, TraktBase):
     def getIMDBids(self):
         movies = []
         for movie in self.getWatchlist():
-            movies.append(movie.get('movie').get('ids').get('imdb'))
+            m = movie.get('movie')
+            m['original_title'] = m['title']
+            log.debug("Movie: %s", m)
+            if self.isMinimalMovie(m):
+                log.info("Trakt automation: %s satisfies requirements, added", m.get('title'))
+                movies.append(m.get('ids').get('imdb'))
+                continue
 
         return movies
 


### PR DESCRIPTION
### Description of what this fixes:
- previously the provider would download _all_ movies on a list
- users should be able to depend on the minimal requirements applying to all providers

### Related issues:
You turned issues off...?