### PR TITLE
Use 7 letter IMDB ID's unless title has an 8 char long IMDB ID.

### DIFF
--- a/couchpotato/core/helpers/variable.py
+++ b/couchpotato/core/helpers/variable.py
@@ -197,9 +197,9 @@ def getImdb(txt, check_inside = False, multiple = False):
         ids = re.findall('(tt\d{4,8})', txt)
 
         if multiple:
-            return removeDuplicate(['tt%08d' % tryInt(x[2:]) for x in ids]) if len(ids) > 0 else []
+            return removeDuplicate(['tt%s' % str(tryInt(x[2:])).rjust(7, '0') for x in ids]) if len(ids) > 0 else []
 
-        return 'tt%08d' % tryInt(ids[0][2:])
+        return 'tt%s' % str(tryInt(ids[0][2:])).rjust(7, '0')
     except IndexError:
         pass
 


### PR DESCRIPTION
### Description of what this fixes:
IMDB still returns 7-char ID's on older titles when searching, simply
blanketin to 8 chars all the time (even if IMDB support 8-char padded
ID's) will ultimately fail lookups on other services.

This allows us to default to a 7-char ID, padded with zero's to ensure
that it still works as expected, but ultimately allow newer 8-char ID's
as-and-when required for newer titles.

Another side effect observed, is that if changing from 7 to 8char as previously done, collections can suffer from duplications, and the Wanted List will repopulate with films which have already downloaded, but with an 8-digit IMDB ID.